### PR TITLE
making ACEtk python bindings a configurable option

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -29,7 +29,7 @@ jobs:
     - name: mkdir bin
       run: mkdir bin
     - name: cmake
-      run: cmake -DPYTHON_EXECUTABLE=$(which python3) -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} ..
+      run: cmake -DPYTHON_EXECUTABLE=$(which python3) -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} -D ACEtk_unit_tests=ON ..
       working-directory: ./bin
     - name: make
       run: make -j2
@@ -37,11 +37,3 @@ jobs:
     - name: ctest
       run: ctest -j2
       working-directory: ./bin
-    - name: make ACEtk.python
-      run: make ACEtk.python -j2
-      working-directory: ./bin
-    - name: python -m unittest
-      run: |
-        cp ../bin/*.so .
-        python3 -m unittest discover -v -p "Test*"
-      working-directory: ./python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,7 @@
 ########################################################################
 # Preamble
 ########################################################################
-
 cmake_minimum_required( VERSION 3.14 )
-
-if(DEFINED PROJECT_NAME)
-  set(subproject ON)
-else()
-  set(subproject OFF)
-endif()
-
 project( ACEtk LANGUAGES CXX )
 
 ########################################################################
@@ -19,7 +11,7 @@ project( ACEtk LANGUAGES CXX )
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED YES )
 
-option( ACEtk_unit_tests "Compile the ACEtk unit tests and integrate with ctest" OFF )
+option(ACEtk_unit_tests "Build the ACEtk unit tests" OFF)
 option( ACEtk.python "Build ACEtk python bindings" ON )
 option( strict_compile
     "Treat all warnings as errors." ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,14 @@
 ########################################################################
 
 cmake_minimum_required( VERSION 3.14 )
-project( ACEtk LANGUAGES CXX )
 
+if(DEFINED PROJECT_NAME)
+  set(subproject ON)
+else()
+  set(subproject OFF)
+endif()
+
+project( ACEtk LANGUAGES CXX )
 
 ########################################################################
 # Project-wide setup
@@ -13,16 +19,15 @@ project( ACEtk LANGUAGES CXX )
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED YES )
 
-option( ACEtk_unit_tests
-    "Compile the ACEtk unit tests and integrate with ctest" ON
-    )
+option( ACEtk_unit_tests "Compile the ACEtk unit tests and integrate with ctest" OFF )
+option( ACEtk.python "Build ACEtk python bindings" ON )
 option( strict_compile
     "Treat all warnings as errors." ON
     )
 
 # Compile flags
-set( common_flags "-Wall" "-Wextra" "-Wpedantic" )
-set( strict_flags "-Werror" )
+set( common_flags "-Wall" "-Wextra" "-Wpedantic" ) # i'm not sure why we manage flags this way...
+set( strict_flags "-Werror" )                      # improving this will need to happen in the future for spack
 set( release_flags "-O3" )
 set( debug_flags "-O0" "-g" )
 
@@ -79,29 +84,26 @@ target_link_libraries( ACEtk
 # ACEtk : python bindings
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-include_directories( python/src/ )
-
-pybind11_add_module( ACEtk.python
-    EXCLUDE_FROM_ALL
+if(ACEtk.python)
+  pybind11_add_module( ACEtk.python 
     python/src/ACEtk.python.cpp
     python/src/Data.python.cpp
     python/src/Table.python.cpp
-)
-target_link_libraries( ACEtk.python PRIVATE ACEtk )
-target_compile_options( ACEtk.python PRIVATE "-fvisibility=hidden" )
-set_target_properties( ACEtk.python PROPERTIES OUTPUT_NAME ACEtk )
-set_target_properties( ACEtk.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
-set_target_properties( ACEtk.python PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  )
+  target_link_libraries( ACEtk.python PRIVATE ACEtk )
+  target_include_directories( ACEtk.python PRIVATE python/src )
+  target_compile_options( ACEtk.python PRIVATE "-fvisibility=hidden" )
+  set_target_properties( ACEtk.python PROPERTIES OUTPUT_NAME ACEtk )
+  set_target_properties( ACEtk.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
+  set_target_properties( ACEtk.python PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 #######################################################################
 # Top-level Only
 #######################################################################
 
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
-
-    # unit testing
-    if( ACEtk_unit_tests )
-        include( cmake/unit_testing.cmake )
-    endif()
-
+  if( ACEtk_unit_tests )
+    include( cmake/unit_testing.cmake )
+  endif()
 endif()

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -29,4 +29,6 @@ add_subdirectory( src/ACEtk/interpretation/MP1/test )
 #######################################################################
 # python tests 
 #######################################################################
-add_subdirectory( python/test )
+if( ACEtk.python )
+  add_subdirectory( python/test )
+endif()


### PR DESCRIPTION
Added new cmake option `ACEtk.python` and set to `ON` by default. For users building the code they can:

```
cmake ${src_dir}
make -jN
```

and they will build the python bindings by deafult so `make ACEtk.python` is no longer required. Further, `ACEtk_unit_tests=OFF` by default, so users that are simply after python bindings will no longer build any testing which cuts build times down significantly. For devs, they must configure as follows:

```
cmake -D ACEtk_unit_tests=ON ${src_dir}
make -jN
```
This will build bindings, and build and  configure all tests (including python tests) such that:

```
ctest -jN
```

works as expected. One may also:

```
cmake -D ACEtk.python=OFF -D ACEtk_unit_tests=ON ${src_dir}
make -jN
ctest -jN # this only runs c++ tests because the python tests are not configured when bindings are off
```