### PR TITLE
Fix/photonuclear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Continuous Integration](https://github.com/njoy/ACEtk/workflows/Continuous%20Integration/badge.svg)
 
+
 # ACEtk
 
 Toolkit for reading and interacting with ACE nuclear data files. This toolkit provides a full C++ library along with python bindings.

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -54,7 +54,7 @@ FetchContent_Declare( range-v3
 
 FetchContent_Declare( pybind11
     GIT_REPOSITORY  https://github.com/pybind/pybind11
-    GIT_TAG         v2.6.1
+    GIT_TAG         v2.10.1
     )
 
 #######################################################################

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -42,7 +42,7 @@ FetchContent_Declare( Log
 
 FetchContent_Declare( pybind11
     GIT_REPOSITORY  https://github.com/pybind/pybind11
-    GIT_TAG         f1abf5d9159b805674197f6bc443592e631c9130 # tag: v2.6.1
+    GIT_TAG         80dc998efced8ceb2be59756668a7e90e8bef917 # tag: v2.10.1
     )
 
 FetchContent_Declare( range-v3

--- a/python/src/PhotonuclearTable.python.cpp
+++ b/python/src/PhotonuclearTable.python.cpp
@@ -322,7 +322,7 @@ void wrapPhotonuclearTable( python::module& module, python::module& ) {
   .def(
 
     "secondary_particle_production_cross_section_block",
-    &Table::secondaryParticleFrameAndMultiplicityBlock,
+    &Table::secondaryParticleProductionCrossSectionBlock,
     python::arg( "index" ),
     "Return the production cross section block for a secondary particle index\n\n"
     "When the index is out of range an out of range exception is thrown\n"


### PR DESCRIPTION
Small correction in the python bindings for the photonuclear ACE file: we pointed to the wrong member function for the SIGH blocks.