### PR TITLE
Updating checkout to v3 to remove deprecation warning on CI

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         which ${{matrix.cxx}}
         ${{matrix.cxx}} --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: mkdir bin
       run: mkdir bin
     - name: cmake


### PR DESCRIPTION
Same change as on ENDFtk: the CI issues deprecation warnings due related to checkout@v2. Changing to v3 solves the issue.