### PR TITLE
Replacing a few XSS(...) calls with IXSS(...) because of rounding

### DIFF
--- a/python/src/block/TabulatedEnergyDistribution.python.cpp
+++ b/python/src/block/TabulatedEnergyDistribution.python.cpp
@@ -47,7 +47,7 @@ void wrapTabulatedEnergyDistribution( python::module& module, python::module& ) 
     "Arguments:\n"
     "    self        the block\n"
     "    incident    the incident energy or cosine value\n"
-    "    cosines     the cosine values\n"
+    "    outgoing    the outgoing energy values\n"
     "    pdf         the pdf values\n"
     "    cdf         the cdf values\n"
     "    discrete    the number of discrete photon lines (defaults to 0)"

--- a/src/ACEtk/block/GeneralEvaporationSpectrum/src/generateBlocks.hpp
+++ b/src/ACEtk/block/GeneralEvaporationSpectrum/src/generateBlocks.hpp
@@ -1,7 +1,7 @@
 void generateBlocks() {
 
-  std::size_t nr = static_cast< std::size_t >( this->XSS( 1 ) );
-  std::size_t ne = static_cast< std::size_t >( this->XSS( 1 + 2 * nr + 1 ) );
+  std::size_t nr = static_cast< std::size_t >( this->IXSS( 1 ) );
+  std::size_t ne = static_cast< std::size_t >( this->IXSS( 1 + 2 * nr + 1 ) );
   auto begin = this->begin();
   auto bins = begin + 2 * nr + 2 * ne + 2;
   auto end = this->end();

--- a/src/ACEtk/block/TabulatedEnergyAngleDistribution/src/generateBlocks.hpp
+++ b/src/ACEtk/block/TabulatedEnergyAngleDistribution/src/generateBlocks.hpp
@@ -1,6 +1,6 @@
 void generateBlocks() {
 
-  std::size_t ne = static_cast< std::size_t >( this->XSS( 2 ) );
+  std::size_t ne = static_cast< std::size_t >( this->IXSS( 2 ) );
   auto data = this->begin() + 1;
   auto end = data + 4 * ne + 1;
 

--- a/src/ACEtk/block/TabulatedEnergyDistribution/src/ctor.hpp
+++ b/src/ACEtk/block/TabulatedEnergyDistribution/src/ctor.hpp
@@ -6,22 +6,22 @@ TabulatedEnergyDistribution( TabulatedEnergyDistribution&& ) = default;
 /**
  *  @brief Constructor
  *
- *  @param[in] incident        the incident energy value
+ *  @param[in] incident        the incident energy or cosine value
  *  @param[in] interpolation   the interpolation type
- *  @param[in] cosines         the cosine values (N values)
+ *  @param[in] outgoing        the outgoing energy values (N values)
  *  @param[in] pdf             the pdf values (N values)
  *  @param[in] cdf             the cdf values (N values)
  *  @param[in] discrete        the number discrete photon lines (defaults to 0)
  */
 TabulatedEnergyDistribution( double incident,
                              int interpolation,
-                             std::vector< double > cosines,
+                             std::vector< double > outgoing,
                              std::vector< double > pdf,
                              std::vector< double > cdf,
                              std::size_t discrete = 0 ) :
   TabulatedProbabilityDistribution(
         "TabulatedEnergyDistribution",
-        discrete * 10 + interpolation, std::move( cosines ),
+        discrete * 10 + interpolation, std::move( outgoing ),
         std::move( pdf ), std::move( cdf ), {} ),
   incident_( incident ) {}
 

--- a/src/ACEtk/block/details/BaseEvaporationSpectrum/src/generateBlocks.hpp
+++ b/src/ACEtk/block/details/BaseEvaporationSpectrum/src/generateBlocks.hpp
@@ -1,7 +1,7 @@
 void generateBlocks() {
 
-  std::size_t nr = static_cast< std::size_t >( round( this->XSS( 1 ) ) );
-  std::size_t ne = static_cast< std::size_t >( round( this->XSS( 1 + 2 * nr + 1 ) ) );
+  std::size_t nr = static_cast< std::size_t >( round( this->IXSS( 1 ) ) );
+  std::size_t ne = static_cast< std::size_t >( round( this->IXSS( 1 + 2 * nr + 1 ) ) );
   auto begin = this->begin();
   auto end = begin + 2 * nr + 2 * ne + 2;
 

--- a/src/ACEtk/block/details/BaseEvaporationSpectrum/src/generateBlocks.hpp
+++ b/src/ACEtk/block/details/BaseEvaporationSpectrum/src/generateBlocks.hpp
@@ -1,7 +1,7 @@
 void generateBlocks() {
 
-  std::size_t nr = static_cast< std::size_t >( round( this->IXSS( 1 ) ) );
-  std::size_t ne = static_cast< std::size_t >( round( this->IXSS( 1 + 2 * nr + 1 ) ) );
+  std::size_t nr = static_cast< std::size_t >( this->IXSS( 1 ) );
+  std::size_t ne = static_cast< std::size_t >( this->IXSS( 1 + 2 * nr + 1 ) );
   auto begin = this->begin();
   auto end = begin + 2 * nr + 2 * ne + 2;
 

--- a/src/ACEtk/block/details/BaseTabulatedData/src/generateBlocks.hpp
+++ b/src/ACEtk/block/details/BaseTabulatedData/src/generateBlocks.hpp
@@ -1,7 +1,7 @@
 void generateBlocks() {
 
-  const auto nr = static_cast< std::size_t >( std::round( this->IXSS( 1 ) ) );
-  const auto ne = static_cast< std::size_t >( std::round( this->IXSS( 1 + 2 * nr + 1 ) ) );
+  const auto nr = static_cast< std::size_t >( this->IXSS( 1 ) );
+  const auto ne = static_cast< std::size_t >( this->IXSS( 1 + 2 * nr + 1 ) );
   const auto begin = this->begin();
   const auto data = begin + 2 * nr + 1;
   const auto end = data + 2 * ne + 1;

--- a/src/ACEtk/block/details/BaseTabulatedData/src/generateBlocks.hpp
+++ b/src/ACEtk/block/details/BaseTabulatedData/src/generateBlocks.hpp
@@ -1,7 +1,7 @@
 void generateBlocks() {
 
-  const auto nr = static_cast< std::size_t >( std::round( this->XSS( 1 ) ) );
-  const auto ne = static_cast< std::size_t >( std::round( this->XSS( 1 + 2 * nr + 1 ) ) );
+  const auto nr = static_cast< std::size_t >( std::round( this->IXSS( 1 ) ) );
+  const auto ne = static_cast< std::size_t >( std::round( this->IXSS( 1 + 2 * nr + 1 ) ) );
   const auto begin = this->begin();
   const auto data = begin + 2 * nr + 1;
   const auto end = data + 2 * ne + 1;


### PR DESCRIPTION
We found a few cases where ACEtk was uncapable of reading an ACE file it generated because integers got read incorrectly (related to #68). In addition, a few more missing IXSS calls were found while looking over the entire code.