### PR TITLE
Feature/eprdata part3

### DIFF
--- a/python/src/PhotoatomicTable.python.cpp
+++ b/python/src/PhotoatomicTable.python.cpp
@@ -262,6 +262,18 @@ void wrapPhotoatomicTable( python::module& module, python::module& ) {
     "heating_numbers_block",
     &Table::heatingNumbersBlock,
     "The heating numbers block"
+  )
+  .def_property_readonly(
+
+    "SUBSH",
+    &Table::SUBSH,
+    "The electron subshell data block for eprdata (NEPR > 0)"
+  )
+  .def_property_readonly(
+
+    "electron_subshell_block",
+    &Table::electronSubshellBlock,
+    "The electron subshell data block for eprdata (NEPR > 0)"
   );
 
   // add standard block definitions

--- a/python/src/block/CoherentFormFactorBlock.python.cpp
+++ b/python/src/block/CoherentFormFactorBlock.python.cpp
@@ -45,19 +45,20 @@ void wrapCoherentFormFactorBlock( python::module& module, python::module& ) {
   .def_property_readonly(
 
     "NM",
-    [] ( const Block& self ) { return self.NM(); },
+    &Block::NM,
     "The number of values"
   )
   .def_property_readonly(
 
     "number_values",
-    [] ( const Block& self ) { return self.numberValues(); },
+    &Block::numberValues,
     "The number of values"
   )
   .def_property_readonly(
 
     "momentum",
-    [] ( const Block& self ) { return self.momentum(); },
+    [] ( const Block& self ) -> DoubleRange
+       { return self.momentum(); },
     "The electron recoil momentum values"
   )
   .def_property_readonly(

--- a/python/src/block/CoherentFormFactorBlock.python.cpp
+++ b/python/src/block/CoherentFormFactorBlock.python.cpp
@@ -42,6 +42,19 @@ void wrapCoherentFormFactorBlock( python::module& module, python::module& ) {
     "    integrated    the integrated form factor values\n"
     "    factors       the form factor values"
   )
+  .def(
+
+    python::init< std::vector< double >, std::vector< double >,
+                  std::vector< double > >(),
+    python::arg( "momentum" ), python::arg( "integrated" ),
+    python::arg( "factors" ),
+    "Initialise the block\n\n"
+    "Arguments:\n"
+    "    self          the block\n"
+    "    momentum      the momentum values\n"
+    "    integrated    the integrated form factor values\n"
+    "    factors       the form factor values"
+  )
   .def_property_readonly(
 
     "NM",

--- a/python/src/block/IncoherentScatteringFunctionBlock.python.cpp
+++ b/python/src/block/IncoherentScatteringFunctionBlock.python.cpp
@@ -46,8 +46,8 @@ void wrapIncoherentScatteringFunctionBlock( python::module& module, python::modu
   )
   .def(
 
-    python::init< std::vector< double > >(),
-    python::arg( "values" ),
+    python::init< std::vector< double >, std::vector< double > >(),
+    python::arg( "momentum" ), python::arg( "values" ),
     "Initialise the block using the eprdata representation\n\n"
     "Arguments:\n"
     "    self        the block\n"

--- a/python/src/block/IncoherentScatteringFunctionBlock.python.cpp
+++ b/python/src/block/IncoherentScatteringFunctionBlock.python.cpp
@@ -24,10 +24,13 @@ void wrapIncoherentScatteringFunctionBlock( python::module& module, python::modu
 
     module,
     "IncoherentScatteringFunctionBlock",
-    "The photoatomic JINC block with the incoherent scattering function values\n\n"
-    "The IncoherentScatteringFunctionBlock class contains the scattering functions\n"
-    "tabulated on a fixed grid of the recoil electron momentum (in inverse\n"
-    "angstroms)."
+    "The photoatomic JINC block with the incoherent scattering function\n\n"
+    "The IncoherentScatteringFunctionBlock class contains one of the following\n"
+    "representations of the scattering function:\n"
+    "  - 21 scattering function values using a fixed momentum grid (mcplib version)\n"
+    "  - tabulated momentum and scattering function values (eprdata version)\n\n"
+    "The interface abstracts away the distinction between the two representations.\n\n"
+    "The recoil electron momentum transfer values are given in inverse angstroms."
   );
 
   // wrap the block
@@ -36,27 +39,38 @@ void wrapIncoherentScatteringFunctionBlock( python::module& module, python::modu
 
     python::init< std::vector< double > >(),
     python::arg( "values" ),
-    "Initialise the block\n\n"
+    "Initialise the block using the mcplib representation\n\n"
     "Arguments:\n"
     "    self       the block\n"
-    "    values     the incoherent scattering function values"
+    "    values     the incoherent scattering function values (21 in total)"
+  )
+  .def(
+
+    python::init< std::vector< double > >(),
+    python::arg( "values" ),
+    "Initialise the block using the eprdata representation\n\n"
+    "Arguments:\n"
+    "    self        the block\n"
+    "    momentum    the momentum values"
+    "    values      the incoherent scattering function values"
   )
   .def_property_readonly(
 
     "NM",
-    [] ( const Block& self ) { return self.NM(); },
+    &Block::NM,
     "The number of values"
   )
   .def_property_readonly(
 
     "number_values",
-    [] ( const Block& self ) { return self.numberValues(); },
+    &Block::numberValues,
     "The number of values"
   )
   .def_property_readonly(
 
     "momentum",
-    [] ( const Block& self ) { return self.momentum(); },
+    [] ( const Block& self ) -> DoubleRange
+       { return self.momentum(); },
     "The electron recoil momentum values"
   )
   .def_property_readonly(

--- a/python/test/block/Test_ACEtk_CoherentFormFactorBlock.py
+++ b/python/test/block/Test_ACEtk_CoherentFormFactorBlock.py
@@ -38,6 +38,10 @@ class Test_ACEtk_CoherentFormFactorBlock( unittest.TestCase ) :
               1.299850000000E-05,  1.111643855704E-05,  9.563173392213E-06,  8.272100115712E-06,
               7.191840373343E-06,  6.282390000000E-06 ]
 
+    chunk_eprdata = [ 0., 1., 1000., 1e+6, 1e+9,
+                      1., 2., 3., 4., 5.,
+                      6., 7., 8., 9., 10. ]
+
     def test_component( self ) :
 
         def verify_chunk( self, chunk ) :
@@ -68,7 +72,35 @@ class Test_ACEtk_CoherentFormFactorBlock( unittest.TestCase ) :
 
                 self.assertAlmostEqual( self.chunk[index], xss[index] )
 
-        # the data is given explicitly
+        def verify_chunk_eprdata( self, chunk ) :
+
+            # verify content
+            self.assertEqual( False, chunk.empty )
+            self.assertEqual( 15, chunk.length )
+            self.assertEqual( "JCOH", chunk.name )
+
+            self.assertEqual( 5, chunk.NM )
+            self.assertEqual( 5, chunk.number_values )
+
+            self.assertEqual( 5, len( chunk.momentum ) )
+            self.assertAlmostEqual( 0.  , chunk.momentum[0] )
+            self.assertAlmostEqual( 1e+9, chunk.momentum[-1] )
+
+            self.assertEqual( 5, len( chunk.integrated_form_factors ) )
+            self.assertAlmostEqual( 1, chunk.integrated_form_factors[0] )
+            self.assertAlmostEqual( 5, chunk.integrated_form_factors[-1] )
+
+            self.assertEqual( 5, len( chunk.form_factors ) )
+            self.assertAlmostEqual(  6., chunk.form_factors[0] )
+            self.assertAlmostEqual( 10., chunk.form_factors[-1] )
+
+            # verify the xss array
+            xss = chunk.xss_array
+            for index in range( chunk.length ) :
+
+                self.assertAlmostEqual( self.chunk_eprdata[index], xss[index] )
+
+        # the data is given explicitly - mcplib style
         chunk = CoherentFormFactorBlock(
                   integrated = [                  0,  9.977954354245E-05,  3.964942506035E-04,  8.824146336660E-04,
                                  1.545120632092E-03,  2.368152245929E-03,  3.328001096461E-03,  5.572765511802E-03,
@@ -101,6 +133,14 @@ class Test_ACEtk_CoherentFormFactorBlock( unittest.TestCase ) :
                               7.191840373343E-06,  6.282390000000E-06 ] )
 
         verify_chunk( self, chunk )
+
+        # the data is given explicitly - eprdata style
+        chunk = CoherentFormFactorBlock(
+                  momentum = [0., 1., 1000., 1e+6, 1e+9 ],
+                  integrated = [ 1., 2., 3., 4., 5. ],
+                  factors = [ 6., 7., 8., 9., 10.] )
+
+        verify_chunk_eprdata( self, chunk )
 
 if __name__ == '__main__' :
 

--- a/python/test/block/Test_ACEtk_IncoherentScatteringFunctionBlock.py
+++ b/python/test/block/Test_ACEtk_IncoherentScatteringFunctionBlock.py
@@ -16,6 +16,9 @@ class Test_ACEtk_IncoherentScatteringFunctionBlock( unittest.TestCase ) :
                9.998980000000E-01,  9.999530000000E-01,  9.999980000000E-01,                   1,
                                 1,                   1,                   1,                   1 ]
 
+    chunk_eprdata = [ 0., 1., 1000., 1e+6, 1e+9,
+                      1., 2., 3., 4., 5. ]
+
     def test_component( self ) :
 
         def verify_chunk( self, chunk ) :
@@ -80,7 +83,37 @@ class Test_ACEtk_IncoherentScatteringFunctionBlock( unittest.TestCase ) :
 
                 self.assertAlmostEqual( self.chunk[index], xss[index] )
 
-        # the data is given explicitly
+        def verify_chunk_eprdata( self, chunk ) :
+
+            # verify content
+            self.assertEqual( False, chunk.empty )
+            self.assertEqual( 10, chunk.length )
+            self.assertEqual( "JINC", chunk.name )
+
+            self.assertEqual( 5, chunk.NM )
+            self.assertEqual( 5, chunk.number_values )
+
+            self.assertEqual( 5, len( chunk.momentum ) )
+            self.assertAlmostEqual( 0.  , chunk.momentum[0] )
+            self.assertAlmostEqual( 1.  , chunk.momentum[1] )
+            self.assertAlmostEqual( 1e+3, chunk.momentum[2] )
+            self.assertAlmostEqual( 1e+6, chunk.momentum[3] )
+            self.assertAlmostEqual( 1e+9, chunk.momentum[4] )
+
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertAlmostEqual( 1, chunk.values[0] )
+            self.assertAlmostEqual( 2, chunk.values[1] )
+            self.assertAlmostEqual( 3, chunk.values[2] )
+            self.assertAlmostEqual( 4, chunk.values[3] )
+            self.assertAlmostEqual( 5, chunk.values[4] )
+
+            # verify the xss array
+            xss = chunk.xss_array
+            for index in range( chunk.length ) :
+
+                self.assertAlmostEqual( self.chunk_eprdata[index], xss[index] )
+
+        # the data is given explicitly - mcnplib style
         chunk = IncoherentScatteringFunctionBlock(
                   values = [                                                                                 0,
                              1.104680000000E-03,  4.409660000000E-03,  1.033110000000E-01,  3.425650000000E-01,
@@ -90,6 +123,13 @@ class Test_ACEtk_IncoherentScatteringFunctionBlock( unittest.TestCase ) :
                                               1,                   1,                   1,                   1 ] )
 
         verify_chunk( self, chunk )
+
+        # the data is given explicitly - eprdata style
+        chunk = IncoherentScatteringFunctionBlock(
+                  momentum = [0., 1., 1000., 1e+6, 1e+9 ],
+                  values = [ 1., 2., 3., 4., 5. ] )
+
+        verify_chunk_eprdata( self, chunk )
 
 if __name__ == '__main__' :
 

--- a/src/ACEtk/PhotoatomicTable.hpp
+++ b/src/ACEtk/PhotoatomicTable.hpp
@@ -12,6 +12,7 @@
 #include "ACEtk/block/PhotoatomicHeatingNumbersBlock.hpp"
 #include "ACEtk/block/PhotoatomicElectronShellBlock.hpp"
 #include "ACEtk/block/PhotoatomicComptonProfileBlock.hpp"
+#include "ACEtk/block/PhotoatomicElectronSubshellBlock.hpp"
 
 namespace njoy {
 namespace ACEtk {
@@ -32,6 +33,7 @@ class PhotoatomicTable : protected Table {
   block::LHNM lhnm_;
   std::optional< block::EPS > eps_;
   std::optional< block::SWD > swd_;
+  std::optional< block::SUBSH > subsh_;
 
   /* auxiliary functions */
   #include "ACEtk/PhotoatomicTable/src/generateBlocks.hpp"
@@ -251,6 +253,19 @@ public:
   const std::optional< block::SWD >& comptonProfileBlock() const {
 
     return this->SWD();
+  }
+
+  /**
+   *  @brief Return the electron subshell data block (NEPR > 0)
+   */
+  const std::optional< block::SUBSH >& SUBSH() const { return this->subsh_; }
+
+  /**
+   *  @brief Return the compton profile block
+   */
+  const std::optional< block::SUBSH >& electronSubshellBlock() const {
+
+    return this->SUBSH();
   }
 };
 

--- a/src/ACEtk/PhotoatomicTable.hpp
+++ b/src/ACEtk/PhotoatomicTable.hpp
@@ -256,12 +256,12 @@ public:
   }
 
   /**
-   *  @brief Return the electron subshell data block (NEPR > 0)
+   *  @brief Return the electron subshell data block for eprdata (NEPR > 0)
    */
   const std::optional< block::SUBSH >& SUBSH() const { return this->subsh_; }
 
   /**
-   *  @brief Return the compton profile block
+   *  @brief Return the electron subshell data block for eprdata (NEPR > 0)
    */
   const std::optional< block::SUBSH >& electronSubshellBlock() const {
 

--- a/src/ACEtk/PhotoatomicTable/src/generateBlocks.hpp
+++ b/src/ACEtk/PhotoatomicTable/src/generateBlocks.hpp
@@ -31,6 +31,7 @@ void generateBlocks() {
   this->jflo_ = std::nullopt;
   this->eps_ = std::nullopt;
   this->swd_ = std::nullopt;
+  this->subsh_ = std::nullopt;
 
   // starting iterator into the XSS array
   auto begin = this->data().XSS().begin();
@@ -73,4 +74,14 @@ void generateBlocks() {
     this->swd_ = block::SWD( locators.first, iterators.first, iterators.second,
                              this->NSH() );
   }
+
+  present = ( this->NEPR() > 0 );
+  if ( present ) {
+
+    // electron subshell block and photolectric subshell cross section block
+    auto subsh = block( 11 );
+    auto sphel = block( 16 );
+    this->subsh_ = block::SUBSH( subsh.first, sphel.first, this->NSSH() );
+  }
 }
+

--- a/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
+++ b/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
@@ -734,5 +734,101 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 94 == chunk.JINC().values().size() );
   CHECK( 0 == Approx( chunk.JINC().values().front() ) );
   CHECK( 1 == Approx( chunk.JINC().values().back() ) );
+
+  // JCOH block
+  CHECK( false == chunk.JCOH().empty() );
+
+  CHECK( 90 == chunk.JCOH().NM() );
+  CHECK( 90 == chunk.JCOH().numberValues() );
+
+  CHECK( 90 == chunk.JCOH().momentum().size() );
+  CHECK( 0.                 == Approx( chunk.JCOH().momentum().front() ) );
+  CHECK( 1.000000000000E+09 == Approx( chunk.JCOH().momentum().back() ) );
+
+  CHECK( 90 == chunk.JCOH().integratedFormFactors().size() );
+  CHECK( 0.                 == Approx( chunk.JCOH().integratedFormFactors().front() ) );
+  CHECK( 3.012861887900E-02 == Approx( chunk.JCOH().integratedFormFactors().back() ) );
+
+  CHECK( 90 == chunk.JCOH().formFactors().size() );
+  CHECK( 1.                 == Approx( chunk.JCOH().formFactors().front() ) );
+  CHECK( 8.182900000000E-39 == Approx( chunk.JCOH().formFactors().back() ) );
+
+  // JFLO block
+  CHECK( false == chunk.JFLO().has_value() );
+
+  // LHNM block
+  CHECK( false == chunk.LHNM().empty() );
+
+  CHECK( 647 == chunk.LHNM().NES() );
+  CHECK( 647 == chunk.LHNM().numberEnergyPoints() );
+  CHECK( 647 == chunk.LHNM().heating().size() );
+
+  CHECK( 8.714616354250E-07 == Approx( chunk.LHNM().heating().front() ) );
+  CHECK( 9.999084183050E+04 == Approx( chunk.LHNM().heating().back() ) );
+
+  // EPS block
+  CHECK( false == chunk.EPS()->empty() );
+
+  CHECK( 1 == chunk.EPS()->NSH() );
+  CHECK( 1 == chunk.EPS()->numberElectronShells() );
+
+  CHECK( 1 == Approx( chunk.EPS()->numberElectrons()[0] ) );
+  CHECK( 1.400000000000e-05 == Approx( chunk.EPS()->bindingEnergies()[0] ) );
+  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbabilities()[0] ) );
+
+  CHECK( 1 == chunk.EPS()->numberElectronsPerShell( 1 ) );
+  CHECK( 1.400000000000e-05 == Approx( chunk.EPS()->bindingEnergy( 1 ) ) );
+  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbability( 1 ) ) );
+
+  // SWD block
+  CHECK( false == chunk.SWD()->empty() );
+
+  CHECK( 1 == chunk.SWD()->NSH() );
+
+  CHECK( 1 == chunk.SWD()->LSWD( 1 ) );
+
+  auto profile = chunk.SWD()->comptonProfile(1);
+  CHECK( 2 == profile.interpolation() );
+  CHECK( 31 == profile.numberValues() );
+  CHECK( 31 == profile.momentum().size() );
+  CHECK( 0. == Approx( profile.momentum().front() ) );
+  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK( 31 == profile.pdf().size() );
+  CHECK( 1.690581458877E+00 == Approx( profile.pdf().front() ) );
+  CHECK( 5.177281263934E-11 == Approx( profile.pdf().back() ) );
+  CHECK( 31 == profile.cdf().size() );
+  CHECK( 0. == Approx( profile.cdf().front() ) );
+  CHECK( 1. == Approx( profile.cdf().back() ) );
+
+  // SUBSH block - EPR data file
+  CHECK( true == chunk.SUBSH().has_value() );
+
+  CHECK( 1 == chunk.SUBSH()->NSSH() );
+  CHECK( 1 == chunk.SUBSH()->numberElectronSubshells() );
+
+  CHECK( 1 == chunk.SUBSH()->ENDF()[0] );
+  CHECK( 1 == chunk.SUBSH()->designators()[0] );
+
+  CHECK( 1 == chunk.SUBSH()->EP()[0] );
+  CHECK( 1 == chunk.SUBSH()->populations()[0] );
+
+  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->BE()[0] ) );
+  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->bindingEnergies()[0] ) );
+
+  CHECK( 1. == Approx( chunk.SUBSH()->CV()[0] ) );
+  CHECK( 1. == Approx( chunk.SUBSH()->vacancyProbabilities()[0] ) );
+
+  CHECK( 0 == chunk.SUBSH()->NT()[0] );
+  CHECK( 0 == chunk.SUBSH()->numberTransitions()[0] );
+
+  CHECK( 1 == chunk.SUBSH()->designator( 1 ) );
+
+  CHECK( 1 == chunk.SUBSH()->population( 1 ) );
+
+  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->bindingEnergy( 1 ) ) );
+
+  CHECK( 1. == Approx( chunk.SUBSH()->vacancyProbability( 1 ) ) );
+
+  CHECK( 0 == chunk.SUBSH()->numberTransitions( 1 ) );
 }
 

--- a/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
+++ b/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
@@ -388,6 +388,9 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
 
   // SWD block
   CHECK( false == chunk.SWD().has_value() );
+
+  // SUBSH block - not an EPR data file
+  CHECK( false == chunk.SUBSH().has_value() );
 }
 
 void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
@@ -530,4 +533,7 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 31 == profile.cdf().size() );
   CHECK( 0. == Approx( profile.cdf().front() ) );
   CHECK( 1. == Approx( profile.cdf().back() ) );
+
+  // SUBSH block - not an EPR data file
+  CHECK( false == chunk.SUBSH().has_value() );
 }

--- a/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
+++ b/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
@@ -11,6 +11,7 @@ using namespace njoy::ACEtk;
 
 void verifyChunkMcplib( const PhotoatomicTable& );
 void verifyChunkMcplib03( const PhotoatomicTable& );
+void verifyChunkEprdata12( const PhotoatomicTable& );
 
 SCENARIO( "PhotoatomicTable" ){
 
@@ -294,6 +295,146 @@ SCENARIO( "PhotoatomicTable" ){
       } // THEN
     } // WHEN
   } // GIVEN
+
+  GIVEN( "valid data for a PhotoatomicTable - eprdata" ) {
+
+    auto table = fromFile( "1000-eprdata12.12p" );
+    std::array< int32_t, 16 > iz = table.data().IZ();
+    std::array< double, 16 > aw = table.data().AW();
+    std::array< int64_t, 16 > nxs = table.data().NXS();
+    std::array< int64_t, 32 > jxs = table.data().JXS();
+    std::vector< double > xss = table.data().XSS();
+
+    WHEN( "constructing a PhotoatomicTable from a table" ) {
+
+      PhotoatomicTable chunk( std::move( table ) );
+
+      THEN( "a PhotoatomicTable can be constructed and members can be "
+            "tested" ) {
+
+        verifyChunkEprdata12( chunk );
+      }
+
+      THEN( "the IZ array is correct" ) {
+
+        decltype(auto) iz_chunk = chunk.data().IZ();
+        CHECK( iz.size() == iz_chunk.size() );
+        for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
+
+          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the AW array is correct" ) {
+
+        decltype(auto) aw_chunk = chunk.data().AW();
+        CHECK( aw.size() == aw_chunk.size() );
+        for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
+
+          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the NXS array is correct" ) {
+
+        decltype(auto) nxs_chunk = chunk.data().NXS();
+        CHECK( nxs.size() == nxs_chunk.size() );
+        for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
+
+          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the JXS array is correct" ) {
+
+        decltype(auto) jxs_chunk = chunk.data().JXS();
+        CHECK( jxs.size() == jxs_chunk.size() );
+        for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
+
+          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        decltype(auto) xss_chunk = chunk.data().XSS();
+        CHECK( xss.size() == xss_chunk.size() );
+        for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN
+
+/*    WHEN( "constructing a PhotoatomicTable from its components" ) {
+
+      PhotoatomicTable base( std::move( table ) );
+
+      PhotoatomicTable chunk( 1, base.header(),
+                              {  },
+                              {  },
+                              base.ESZG(), base.JINC(),
+                              base.JCOH(), base.LHNM(),
+                              std::nullopt,
+                              base.EPS(), base.SWD() );
+
+      THEN( "a PhotoatomicTable can be constructed and members can be "
+            "tested" ) {
+
+        verifyChunkEprdata12( chunk );
+      }
+
+      THEN( "the IZ array is correct" ) {
+
+        decltype(auto) iz_chunk = chunk.data().IZ();
+        CHECK( iz.size() == iz_chunk.size() );
+        for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
+
+          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the AW array is correct" ) {
+
+        decltype(auto) aw_chunk = chunk.data().AW();
+        CHECK( aw.size() == aw_chunk.size() );
+        for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
+
+          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the NXS array is correct" ) {
+
+        decltype(auto) nxs_chunk = chunk.data().NXS();
+        CHECK( nxs.size() == nxs_chunk.size() );
+        for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
+
+          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the JXS array is correct" ) {
+
+        decltype(auto) jxs_chunk = chunk.data().JXS();
+        CHECK( jxs.size() == jxs_chunk.size() );
+        for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
+
+          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+        }
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        decltype(auto) xss_chunk = chunk.data().XSS();
+        CHECK( xss.size() == xss_chunk.size() );
+        for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN*/
+  } // GIVEN
 } // SCENARIO
 
 void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
@@ -537,3 +678,61 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   // SUBSH block - not an EPR data file
   CHECK( false == chunk.SUBSH().has_value() );
 }
+
+void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
+
+  CHECK( "1000.12p" == chunk.ZAID() );
+  CHECK( 0. == Approx( chunk.temperature() ) );
+
+  CHECK( 12025 == chunk.length() );
+  CHECK( 647 == chunk.NES() );
+  CHECK( 647 == chunk.numberEnergyPoints() );
+  CHECK( 0 == chunk.NFLO() );
+  CHECK( 0 == chunk.numberFluorescenceEdges() );
+  CHECK( 1 == chunk.NSH() );
+  CHECK( 1 == chunk.numberElectronShells() );
+
+  // this is an EPR data file
+  CHECK( 1 == chunk.NEPR() );
+  CHECK( 1 == chunk.electronPhotonRelaxationFormat() );
+  CHECK( 1 == chunk.NSSH() );
+  CHECK( 1 == chunk.numberElectronSubshells() );
+
+  // ESZG block
+  CHECK( false == chunk.ESZG().empty() );
+
+  CHECK( 647 == chunk.ESZG().NES() );
+  CHECK( 647 == chunk.ESZG().numberEnergyPoints() );
+
+  CHECK( 647 == chunk.ESZG().energies().size() );
+  CHECK( 647 == chunk.ESZG().incoherent().size() );
+  CHECK( 647 == chunk.ESZG().coherent().size() );
+  CHECK( 647 == chunk.ESZG().photoelectric().size() );
+  CHECK( 647 == chunk.ESZG().pairproduction().size() );
+
+  CHECK( -1.381551055796E+01 == Approx( chunk.ESZG().energies().front() ) );
+  CHECK(  1.151292546497E+01 == Approx( chunk.ESZG().energies().back() ) );
+  CHECK( -1.616285246005E+01 == Approx( chunk.ESZG().incoherent().front() ) );
+  CHECK( -1.097982967256E+01 == Approx( chunk.ESZG().incoherent().back() ) );
+  CHECK( -1.152423386458E+01 == Approx( chunk.ESZG().coherent().front() ) );
+  CHECK( -3.530963433758E+01 == Approx( chunk.ESZG().coherent().back() ) );
+  CHECK(                   0 == Approx( chunk.ESZG().photoelectric().front() ) );
+  CHECK( -3.249289163676E+01 == Approx( chunk.ESZG().photoelectric().back() ) );
+  CHECK(                   0 == Approx( chunk.ESZG().pairproduction().front() ) );
+  CHECK( -3.877573270699E+00 == Approx( chunk.ESZG().pairproduction().back() ) );
+
+  // JINC block
+  CHECK( false == chunk.JINC().empty() );
+
+  CHECK( 94 == chunk.JINC().NM() );
+  CHECK( 94 == chunk.JINC().numberValues() );
+
+  CHECK( 94 == chunk.JINC().momentum().size() );
+  CHECK( 1.000000000000E-07 == Approx( chunk.JINC().momentum().front() ) );
+  CHECK( 1.000000000000E+09   == Approx( chunk.JINC().momentum().back() ) );
+
+  CHECK( 94 == chunk.JINC().values().size() );
+  CHECK( 0 == Approx( chunk.JINC().values().front() ) );
+  CHECK( 1 == Approx( chunk.JINC().values().back() ) );
+}
+

--- a/src/ACEtk/block/CoherentFormFactorBlock.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock.hpp
@@ -15,17 +15,21 @@ namespace block {
  *  @class
  *  @brief The photoatomic JCOH block with the coherent form factors
  *
- *  The CoherentFormFactorBlock class contains coherent form factors that are
- *  used to modify the differential Thomson cross section tabulated on a fixed
- *  grid of the recoil electron momentum transfer (in inverse angstroms).
+ *  The CoherentFormFactorBlock class contains one of the following
+ *  representations of the form factor:
+ *    - 55 values for the form factor and its integral form using a fixed 
+ *      momentum grid (mcplib version)
+ *    - tabulated form factor and its integral form (eprdata version)
  */
 class CoherentFormFactorBlock : protected details::ArrayData {
 
   /* fields */
+  std::optional< std::vector< double > > momentum_;
 
   /* auxiliary functions */
-  #include "ACEtk/block/CrossSectionData/src/generateXSS.hpp"
-  #include "ACEtk/block/CrossSectionData/src/verifySize.hpp"
+  #include "ACEtk/block/CoherentFormFactorBlock/src/numberElements.hpp"
+  #include "ACEtk/block/CoherentFormFactorBlock/src/numberArrays.hpp"
+  #include "ACEtk/block/CoherentFormFactorBlock/src/generateArrays.hpp"
 
 public:
 
@@ -37,36 +41,46 @@ public:
   /**
    *  @brief Return the number of values
    */
-  static constexpr unsigned int NM() { return 55; }
+  unsigned int NM() const { return this->N(); }
 
   /**
    *  @brief Return the number of values
    */
-  static constexpr unsigned int numberValues() { return NM(); }
+  unsigned int numberValues() const { return NM(); }
 
   /**
    *  @brief Return the electron recoil momentum values
    */
-  static constexpr std::array< double, 55 > momentum() {
+  auto momentum() const {
 
-    return {{ 0., .01, .02, .03, .04, .05, .06, .08, .10, .12, .15,
-              .18, .20, .25, .30, .35, .40, .45, .50, .55, .60, .70,
-              .80, .90, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8,
-              1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8,
-              4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0 }};
+    if ( this->momentum_.has_value() ) {
+
+      return ranges::make_subrange( this->momentum_.value().begin(), 
+                                    this->momentum_.value().end() );
+    }
+    else {
+
+      return this->darray( 1 );
+    }
   }
 
   /**
    *  @brief Return the integrated form factor values (tabulated on a grid of
    *         squared momentum values)
    */
-  auto integratedFormFactors() const { return this->darray( 1 ); }
+  auto integratedFormFactors() const { 
+
+    return this->darray( this->momentum_.has_value() ? 1 : 2 );
+  }
 
   /**
    *  @brief Return the form factor values (tabulated on a grid of momentum
    *         values)
    */
-  auto formFactors() const { return this->darray( 2 ); }
+  auto formFactors() const { 
+
+    return this->darray( this->momentum_.has_value() ? 2 : 3 );
+  }
 
   using ArrayData::empty;
   using ArrayData::name;

--- a/src/ACEtk/block/CoherentFormFactorBlock.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock.hpp
@@ -16,7 +16,7 @@ namespace block {
  *  @brief The photoatomic JCOH block with the coherent form factors
  *
  *  The CoherentFormFactorBlock class contains coherent form factors that are
- *  used to modify the differential Thomson cross sectiontabulated on a fixed
+ *  used to modify the differential Thomson cross section tabulated on a fixed
  *  grid of the recoil electron momentum transfer (in inverse angstroms).
  */
 class CoherentFormFactorBlock : protected details::ArrayData {

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/ctor.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/ctor.hpp
@@ -24,14 +24,14 @@ CoherentFormFactorBlock( std::vector< double > integrated,
 /**
  *  @brief Constructor
  *
- *  @param[in] momentum      the momemtum values
+ *  @param[in] momentum      the momentum values
  *  @param[in] integrated    the integrated form factor values
  *  @param[in] factors       the form factor values
  */
 CoherentFormFactorBlock( std::vector< double > momentum,
                          std::vector< double > integrated,
                          std::vector< double > factors ) :
-  ArrayData( "JCOH", std::move( momentum ), std::move( integrated ), 
+  ArrayData( "JCOH", std::move( momentum ), std::move( integrated ),
                      std::move( factors ) ) {}
 
 private :
@@ -39,8 +39,8 @@ private :
 /**
  *  @brief Private intermediate constructor
  */
-CoherentFormFactorBlock( Iterator begin, Iterator end, 
-                         unsigned int size, 
+CoherentFormFactorBlock( Iterator begin, Iterator end,
+                         unsigned int size,
                          unsigned int n, unsigned int m ) :
   ArrayData( "JCOH", begin, end, n, m ), momentum_( std::nullopt ) {
 
@@ -63,11 +63,10 @@ public:
  *  @param[in] end     the end iterator of the JINC block in the XSS array
  */
 CoherentFormFactorBlock( Iterator begin, Iterator end ) :
-  CoherentFormFactorBlock( begin, end, 
-                           std::distance( begin, end ), 
-                           numberElements( begin, end ), 
+  CoherentFormFactorBlock( begin, end,
+                           std::distance( begin, end ),
+                           numberElements( begin, end ),
                            numberArrays( begin, end ) ) {}
 
 CoherentFormFactorBlock& operator=( const CoherentFormFactorBlock& ) = default;
 CoherentFormFactorBlock& operator=( CoherentFormFactorBlock&& ) = default;
-

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/ctor.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/ctor.hpp
@@ -12,8 +12,49 @@ CoherentFormFactorBlock( CoherentFormFactorBlock&& ) = default;
 CoherentFormFactorBlock( std::vector< double > integrated,
                          std::vector< double > factors ) :
   ArrayData( "JCOH",
-             std::vector< std::vector< double > >{ std::move( integrated ),
-                                                   std::move( factors ) } ) {}
+             generateArrays( std::move( integrated ), std::move( factors ) ) ) {
+
+  momentum_ = {{ 0., .01, .02, .03, .04, .05, .06, .08, .10, .12, .15,
+                .18, .20, .25, .30, .35, .40, .45, .50, .55, .60, .70,
+                .80, .90, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8,
+                1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8,
+                4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0 }};
+}
+
+/**
+ *  @brief Constructor
+ *
+ *  @param[in] momentum      the momemtum values
+ *  @param[in] integrated    the integrated form factor values
+ *  @param[in] factors       the form factor values
+ */
+CoherentFormFactorBlock( std::vector< double > momentum,
+                         std::vector< double > integrated,
+                         std::vector< double > factors ) :
+  ArrayData( "JCOH", std::move( momentum ), std::move( integrated ), 
+                     std::move( factors ) ) {}
+
+private :
+
+/**
+ *  @brief Private intermediate constructor
+ */
+CoherentFormFactorBlock( Iterator begin, Iterator end, 
+                         unsigned int size, 
+                         unsigned int n, unsigned int m ) :
+  ArrayData( "JCOH", begin, end, n, m ), momentum_( std::nullopt ) {
+
+  if ( size == 110 ) {
+
+    momentum_ = {{ 0., .01, .02, .03, .04, .05, .06, .08, .10, .12, .15,
+                  .18, .20, .25, .30, .35, .40, .45, .50, .55, .60, .70,
+                  .80, .90, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8,
+                  1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8,
+                  4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0 }};
+  }
+}
+
+public:
 
 /**
  *  @brief Constructor
@@ -22,7 +63,11 @@ CoherentFormFactorBlock( std::vector< double > integrated,
  *  @param[in] end     the end iterator of the JINC block in the XSS array
  */
 CoherentFormFactorBlock( Iterator begin, Iterator end ) :
-  ArrayData( "JCOH", begin, end, 55, 2 ) {}
+  CoherentFormFactorBlock( begin, end, 
+                           std::distance( begin, end ), 
+                           numberElements( begin, end ), 
+                           numberArrays( begin, end ) ) {}
 
 CoherentFormFactorBlock& operator=( const CoherentFormFactorBlock& ) = default;
 CoherentFormFactorBlock& operator=( CoherentFormFactorBlock&& ) = default;
+

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/generateArrays.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/generateArrays.hpp
@@ -1,0 +1,13 @@
+static std::vector< std::vector< double > > 
+generateArrays( std::vector< double > integrated, std::vector< double > factors ) {
+
+  if ( 110 != integrated.size() + factors.size() ) {
+
+    Log::error( "The size of the XSS subrange in the JINC block for an "
+                "mcplib style form factors should be two times 55" );
+    Log::info( "integrated form factors size(): {}", integrated.size() );
+    Log::info( "form factors size(): {}", factors.size() );
+    throw std::exception();
+  }
+  return { std::move( integrated ), std::move( factors ) };
+}

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/numberArrays.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/numberArrays.hpp
@@ -1,0 +1,4 @@
+static unsigned int numberArrays( Iterator begin, Iterator end ) {
+
+  return std::distance( begin, end ) == 110 ? 2 : 3;
+}

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/numberElements.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/numberElements.hpp
@@ -7,7 +7,7 @@ static unsigned int numberElements( Iterator begin, Iterator end ) {
   }
   else {
 
-    if ( 0 != size%3 ) {
+    if ( 0 != size % 3 ) {
 
       Log::error( "The size of the XSS subrange in the JCOH block for"
                   "arbitrarily tabulated form factors should be odd" );

--- a/src/ACEtk/block/CoherentFormFactorBlock/src/numberElements.hpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/src/numberElements.hpp
@@ -1,0 +1,19 @@
+static unsigned int numberElements( Iterator begin, Iterator end ) {
+
+  auto size = std::distance( begin, end );
+  if ( 110 == size ) {
+
+    return 55;
+  }
+  else {
+
+    if ( 0 != size%3 ) {
+
+      Log::error( "The size of the XSS subrange in the JCOH block for"
+                  "arbitrarily tabulated form factors should be odd" );
+      Log::info( "XSS.size(): {}", size );
+      throw std::exception();
+    }
+    return size / 3;
+  }
+}

--- a/src/ACEtk/block/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
+++ b/src/ACEtk/block/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
@@ -10,11 +10,13 @@ using namespace njoy::ACEtk;
 using CoherentFormFactorBlock = block::CoherentFormFactorBlock;
 
 std::vector< double > chunk();
+std::vector< double > chunkEprdata();
 void verifyChunk( const CoherentFormFactorBlock& );
+void verifyChunkEprdata( const CoherentFormFactorBlock& );
 
 SCENARIO( "CoherentFormFactorBlock" ) {
 
-  GIVEN( "valid data for a CoherentFormFactorBlock instance" ) {
+  GIVEN( "valid data for a CoherentFormFactorBlock instance - mcplib style" ) {
 
     std::vector< double > xss = chunk();
 
@@ -94,6 +96,57 @@ SCENARIO( "CoherentFormFactorBlock" ) {
       } // THEN
     } // WHEN
   } // GIVEN
+
+  GIVEN( "valid data for a CoherentFormFactorBlock instance - eprdata style" ) {
+
+    std::vector< double > xss = chunkEprdata();
+
+    WHEN( "the data is given explicitly" ) {
+
+      std::vector< double > momentum = { 0., 1., 1000., 1e+6, 1e+9 };
+      std::vector< double > integrated = { 1., 2., 3., 4., 5. };
+      std::vector< double > factors = { 6., 7., 8., 9., 10. };
+
+      CoherentFormFactorBlock chunk( std::move( momentum ),
+                                     std::move( integrated ),
+                                     std::move( factors ) );
+
+      THEN( "a CoherentFormFactorBlock can be constructed and members can "
+            "be tested" ) {
+
+        verifyChunkEprdata( chunk );
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        auto xss_chunk = chunk.XSS();
+        for ( unsigned int i = 0; i < chunk.length(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is defined by iterators" ) {
+
+      CoherentFormFactorBlock chunk( xss.begin(), xss.end() );
+
+      THEN( "a CoherentFormFactorBlock can be constructed and members can "
+            "be tested" ) {
+
+        verifyChunkEprdata( chunk );
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        auto xss_chunk = chunk.XSS();
+        for ( unsigned int i = 0; i < chunk.length(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN
+  } // GIVEN
 } // SCENARIO
 
 std::vector< double > chunk() {
@@ -131,6 +184,16 @@ std::vector< double > chunk() {
   };
 }
 
+std::vector< double > chunkEprdata() {
+
+  return {
+
+    0., 1., 1000., 1e+6, 1e+9,
+    1., 2., 3., 4., 5.,
+    6., 7., 8., 9., 10.
+  };
+}
+
 void verifyChunk( const CoherentFormFactorBlock& chunk ) {
 
   CHECK( false == chunk.empty() );
@@ -141,14 +204,36 @@ void verifyChunk( const CoherentFormFactorBlock& chunk ) {
   CHECK( 55 == chunk.numberValues() );
 
   CHECK( 55 == chunk.momentum().size() );
-  CHECK( 0.   == Approx( chunk.momentum()[0] ) );
-  CHECK( 6.   == Approx( chunk.momentum()[54] ) );
+  CHECK( 0.   == Approx( chunk.momentum().front() ) );
+  CHECK( 6.   == Approx( chunk.momentum().back() ) );
 
   CHECK( 55 == chunk.integratedFormFactors().size() );
   CHECK( 0. == Approx( chunk.integratedFormFactors()[0] ) );
-  CHECK( 3.058316405266E-02 == Approx( chunk.integratedFormFactors()[54] ) );
+  CHECK( 3.058316405266E-02 == Approx( chunk.integratedFormFactors().back() ) );
 
   CHECK( 55 == chunk.formFactors().size() );
   CHECK( 1. == Approx( chunk.formFactors()[0] ) );
-  CHECK( 6.282390000000E-06 == Approx( chunk.formFactors()[54] ) );
+  CHECK( 6.282390000000E-06 == Approx( chunk.formFactors().back() ) );
+}
+
+void verifyChunkEprdata( const CoherentFormFactorBlock& chunk ) {
+
+  CHECK( false == chunk.empty() );
+  CHECK( 15 == chunk.length() );
+  CHECK( "JCOH" == chunk.name() );
+
+  CHECK( 5 == chunk.NM() );
+  CHECK( 5 == chunk.numberValues() );
+
+  CHECK( 5 == chunk.momentum().size() );
+  CHECK( 0.   == Approx( chunk.momentum().front() ) );
+  CHECK( 1e+9 == Approx( chunk.momentum().back() ) );
+
+  CHECK( 5 == chunk.integratedFormFactors().size() );
+  CHECK( 1. == Approx( chunk.integratedFormFactors().front() ) );
+  CHECK( 5. == Approx( chunk.integratedFormFactors().back() ) );
+
+  CHECK( 5 == chunk.formFactors().size() );
+  CHECK(  6. == Approx( chunk.formFactors().front() ) );
+  CHECK( 10. == Approx( chunk.formFactors().back() ) );
 }

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock.hpp
@@ -13,17 +13,26 @@ namespace block {
 
 /**
  *  @class
- *  @brief The photoatomic JINC block with the incoherent scattering function values
+ *  @brief The photoatomic JINC block with the incoherent scattering function
  *
- *  The IncoherentScatteringFunctionBlock class contains the scattering functions
- *  tabulated on a fixed grid of the recoil electron momentum transfer (in inverse
- *  angstroms).
+ *  The IncoherentScatteringFunctionBlock class contains one of the following
+ *  representations of the scattering function:
+ *    - 21 scattering function values using a fixed momentum grid (mcplib version)
+ *    - tabulated momentum and scattering function values (eprdata version)
+ *
+ *  The interface abstracts away the distinction between the two representations.
+ *
+ *  The recoil electron momentum transfer values are given in inverse angstroms.
  */
 class IncoherentScatteringFunctionBlock : protected details::ArrayData {
 
   /* fields */
+  std::optional< std::vector< double > > momentum_;
 
   /* auxiliary functions */
+  #include "ACEtk/block/IncoherentScatteringFunctionBlock/src/numberElements.hpp"
+  #include "ACEtk/block/IncoherentScatteringFunctionBlock/src/numberArrays.hpp"
+  #include "ACEtk/block/IncoherentScatteringFunctionBlock/src/generateArrays.hpp"
 
 public:
 
@@ -35,26 +44,36 @@ public:
   /**
    *  @brief Return the number of values
    */
-  static constexpr unsigned int NM() { return 21; }
+  unsigned int NM() const { return this->N(); }
 
   /**
    *  @brief Return the number of values
    */
-  static constexpr unsigned int numberValues() { return NM(); }
+  unsigned int numberValues() const { return NM(); }
 
   /**
    *  @brief Return the electron recoil momentum values
    */
-  static constexpr std::array< double, 21 > momentum() {
+  auto momentum() const {
 
-    return {{ 0., .005, .01, .05, .1, .15, .2,
-              .3, .4, .5, .6, .7, .8, .9, 1., 1.5, 2., 3., 4., 5., 8. }};
+    if ( this->momentum_.has_value() ) {
+
+      return ranges::make_subrange( this->momentum_.value().begin(), 
+                                    this->momentum_.value().end() );
+    }
+    else {
+
+      return this->darray( 1 );
+    }
   }
 
   /**
    *  @brief Return the scattering function values
    */
-  auto values() const { return this->darray( 1 ); }
+  auto values() const { 
+
+    return this->darray( this->momentum_.has_value() ? 1 : 2 );
+  }
 
   using ArrayData::empty;
   using ArrayData::name;

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/ctor.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/ctor.hpp
@@ -19,7 +19,7 @@ IncoherentScatteringFunctionBlock( std::vector< double > values ) :
 /**
  *  @brief Constructor
  *
- *  @param[in] momentum    the momemtum values
+ *  @param[in] momentum    the momentum values
  *  @param[in] values      the scattering function values
  */
 IncoherentScatteringFunctionBlock( std::vector< double > momentum,
@@ -31,8 +31,8 @@ private :
 /**
  *  @brief Private intermediate constructor
  */
-IncoherentScatteringFunctionBlock( Iterator begin, Iterator end, 
-                                   unsigned int size, 
+IncoherentScatteringFunctionBlock( Iterator begin, Iterator end,
+                                   unsigned int size,
                                    unsigned int n, unsigned int m ) :
   ArrayData( "JINC", begin, end, n, m ), momentum_( std::nullopt ) {
 
@@ -52,11 +52,10 @@ public:
  *  @param[in] end     the end iterator of the JINC block in the XSS array
  */
 IncoherentScatteringFunctionBlock( Iterator begin, Iterator end ) :
-  IncoherentScatteringFunctionBlock( begin, end, 
-                                     std::distance( begin, end ), 
-                                     numberElements( begin, end ), 
+  IncoherentScatteringFunctionBlock( begin, end,
+                                     std::distance( begin, end ),
+                                     numberElements( begin, end ),
                                      numberArrays( begin, end ) ) {}
 
 IncoherentScatteringFunctionBlock& operator=( const IncoherentScatteringFunctionBlock& ) = default;
 IncoherentScatteringFunctionBlock& operator=( IncoherentScatteringFunctionBlock&& ) = default;
-

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/ctor.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/ctor.hpp
@@ -10,7 +10,40 @@ IncoherentScatteringFunctionBlock( IncoherentScatteringFunctionBlock&& ) = defau
  */
 IncoherentScatteringFunctionBlock( std::vector< double > values ) :
   ArrayData( "JINC",
-             std::vector< std::vector< double > >{ std::move( values ) } ) {}
+             generateArrays( std::move( values ) ) ) {
+
+  momentum_ = {{ 0., .005, .01, .05, .1, .15, .2,
+                 .3, .4, .5, .6, .7, .8, .9, 1., 1.5, 2., 3., 4., 5., 8. }};
+}
+
+/**
+ *  @brief Constructor
+ *
+ *  @param[in] momentum    the momemtum values
+ *  @param[in] values      the scattering function values
+ */
+IncoherentScatteringFunctionBlock( std::vector< double > momentum,
+                                   std::vector< double > values ) :
+  ArrayData( "JINC", std::move( momentum ), std::move( values ) ) {}
+
+private :
+
+/**
+ *  @brief Private intermediate constructor
+ */
+IncoherentScatteringFunctionBlock( Iterator begin, Iterator end, 
+                                   unsigned int size, 
+                                   unsigned int n, unsigned int m ) :
+  ArrayData( "JINC", begin, end, n, m ), momentum_( std::nullopt ) {
+
+  if ( size == 21 ) {
+
+    momentum_ = {{ 0., .005, .01, .05, .1, .15, .2,
+                   .3, .4, .5, .6, .7, .8, .9, 1., 1.5, 2., 3., 4., 5., 8. }};
+  }
+}
+
+public:
 
 /**
  *  @brief Constructor
@@ -19,7 +52,11 @@ IncoherentScatteringFunctionBlock( std::vector< double > values ) :
  *  @param[in] end     the end iterator of the JINC block in the XSS array
  */
 IncoherentScatteringFunctionBlock( Iterator begin, Iterator end ) :
-  ArrayData( "JINC", begin, end, 21, 1 ) {}
+  IncoherentScatteringFunctionBlock( begin, end, 
+                                     std::distance( begin, end ), 
+                                     numberElements( begin, end ), 
+                                     numberArrays( begin, end ) ) {}
 
 IncoherentScatteringFunctionBlock& operator=( const IncoherentScatteringFunctionBlock& ) = default;
 IncoherentScatteringFunctionBlock& operator=( IncoherentScatteringFunctionBlock&& ) = default;
+

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/generateArrays.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/generateArrays.hpp
@@ -1,0 +1,12 @@
+static std::vector< std::vector< double > > 
+generateArrays( std::vector< double > values ) {
+
+  if ( 21 == values.size() ) {
+
+    Log::error( "The size of the XSS subrange in the JINC block for an "
+                "mcplib style scattering function should be 21" );
+    Log::info( "XSS.size(): {}", values.size() );
+    throw std::exception();
+  }
+  return { std::move( values ) };
+}

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/generateArrays.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/generateArrays.hpp
@@ -1,7 +1,7 @@
 static std::vector< std::vector< double > > 
 generateArrays( std::vector< double > values ) {
 
-  if ( 21 == values.size() ) {
+  if ( 21 != values.size() ) {
 
     Log::error( "The size of the XSS subrange in the JINC block for an "
                 "mcplib style scattering function should be 21" );

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberArrays.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberArrays.hpp
@@ -1,0 +1,4 @@
+static unsigned int numberArrays( Iterator begin, Iterator end ) {
+
+  return std::distance( begin, end ) == 21 ? 1 : 2;
+}

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberElements.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberElements.hpp
@@ -7,7 +7,7 @@ static unsigned int numberElements( Iterator begin, Iterator end ) {
   }
   else {
 
-    if ( 0 != size%2 ) {
+    if ( 0 != size % 2 ) {
 
       Log::error( "The size of the XSS subrange in the JINC block for an "
                   "arbitrarily tabulated scattering function should be even" );

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberElements.hpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/src/numberElements.hpp
@@ -1,0 +1,19 @@
+static unsigned int numberElements( Iterator begin, Iterator end ) {
+
+  auto size = std::distance( begin, end );
+  if ( 21 == size ) {
+
+    return 21;
+  }
+  else {
+
+    if ( 0 != size%2 ) {
+
+      Log::error( "The size of the XSS subrange in the JINC block for an "
+                  "arbitrarily tabulated scattering function should be even" );
+      Log::info( "XSS.size(): {}", size );
+      throw std::exception();
+    }
+    return size / 2;
+  }
+}

--- a/src/ACEtk/block/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
+++ b/src/ACEtk/block/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
@@ -10,11 +10,13 @@ using namespace njoy::ACEtk;
 using IncoherentScatteringFunctionBlock = block::IncoherentScatteringFunctionBlock;
 
 std::vector< double > chunk();
+std::vector< double > chunkEprdata();
 void verifyChunk( const IncoherentScatteringFunctionBlock& );
+void verifyChunkEprdata( const IncoherentScatteringFunctionBlock& );
 
 SCENARIO( "IncoherentScatteringFunctionBlock" ) {
 
-  GIVEN( "valid data for a IncoherentScatteringFunctionBlock instance" ) {
+  GIVEN( "valid data for a IncoherentScatteringFunctionBlock instance - mcplib style" ) {
 
     std::vector< double > xss = chunk();
 
@@ -68,6 +70,55 @@ SCENARIO( "IncoherentScatteringFunctionBlock" ) {
       } // THEN
     } // WHEN
   } // GIVEN
+
+  GIVEN( "valid data for a IncoherentScatteringFunctionBlock instance - eprdata style" ) {
+
+    std::vector< double > xss = chunkEprdata();
+
+    WHEN( "the data is given explicitly" ) {
+
+      std::vector< double > momentum = { 0., 1., 1000., 1e+6, 1e+9 };
+      std::vector< double > values = { 1., 2., 3., 4., 5. };
+
+      IncoherentScatteringFunctionBlock chunk( std::move( momentum ),
+                                               std::move( values ) );
+
+      THEN( "a IncoherentScatteringFunctionBlock can be constructed and members can "
+            "be tested" ) {
+
+        verifyChunkEprdata( chunk );
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        auto xss_chunk = chunk.XSS();
+        for ( unsigned int i = 0; i < chunk.length(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN
+
+    WHEN( "the data is defined by iterators" ) {
+
+      IncoherentScatteringFunctionBlock chunk( xss.begin(), xss.end() );
+
+      THEN( "a IncoherentScatteringFunctionBlock can be constructed and members can "
+            "be tested" ) {
+
+        verifyChunkEprdata( chunk );
+      } // THEN
+
+      THEN( "the XSS array is correct" ) {
+
+        auto xss_chunk = chunk.XSS();
+        for ( unsigned int i = 0; i < chunk.length(); ++i ) {
+
+          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+        }
+      } // THEN
+    } // WHEN
+  } // GIVEN
 } // SCENARIO
 
 std::vector< double > chunk() {
@@ -79,6 +130,15 @@ std::vector< double > chunk() {
            9.950160000000E-01,  9.983740000000E-01,  9.994100000000E-01,  9.997650000000E-01,
            9.998980000000E-01,  9.999530000000E-01,  9.999980000000E-01,                   1,
                             1,                   1,                   1,                   1
+  };
+}
+
+std::vector< double > chunkEprdata() {
+
+  return {
+
+    0., 1., 1000., 1e+6, 1e+9,
+    1., 2., 3., 4., 5.
   };
 }
 
@@ -136,4 +196,28 @@ void verifyChunk( const IncoherentScatteringFunctionBlock& chunk ) {
   CHECK( 1 == Approx( chunk.values()[18] ) );
   CHECK( 1 == Approx( chunk.values()[19] ) );
   CHECK( 1 == Approx( chunk.values()[20] ) );
+}
+
+void verifyChunkEprdata( const IncoherentScatteringFunctionBlock& chunk ) {
+
+  CHECK( false == chunk.empty() );
+  CHECK( 10 == chunk.length() );
+  CHECK( "JINC" == chunk.name() );
+
+  CHECK( 5 == chunk.NM() );
+  CHECK( 5 == chunk.numberValues() );
+
+  CHECK( 5 == chunk.momentum().size() );
+  CHECK( 0.   == Approx( chunk.momentum()[0] ) );
+  CHECK( 1.   == Approx( chunk.momentum()[1] ) );
+  CHECK( 1e+3 == Approx( chunk.momentum()[2] ) );
+  CHECK( 1e+6 == Approx( chunk.momentum()[3] ) );
+  CHECK( 1e+9 == Approx( chunk.momentum()[4] ) );
+
+  CHECK( 5 == chunk.values().size() );
+  CHECK( 1 == Approx( chunk.values()[0] ) );
+  CHECK( 2. == Approx( chunk.values()[1] ) );
+  CHECK( 3. == Approx( chunk.values()[2] ) );
+  CHECK( 4. == Approx( chunk.values()[3] ) );
+  CHECK( 5. == Approx( chunk.values()[4] ) );
 }

--- a/src/ACEtk/block/details/ArrayData/src/ctor.hpp
+++ b/src/ACEtk/block/details/ArrayData/src/ctor.hpp
@@ -30,6 +30,22 @@ ArrayData( std::string&& name, std::vector< std::vector< Number > >&& values ) :
  *  @param[in] name     the name of the block
  *  @param[in] array1   the values for array 1
  *  @param[in] array2   the values for array 2
+ */
+template < typename Number >
+ArrayData( std::string&& name,
+           std::vector< Number >&& array1,
+           std::vector< Number >&& array2 ) :
+  ArrayData( std::move( name ),
+             std::vector< std::vector< Number > >{
+
+               std::move( array1 ), std::move( array2 ) } ) {}
+
+/**
+ *  @brief Convenience constructor
+ *
+ *  @param[in] name     the name of the block
+ *  @param[in] array1   the values for array 1
+ *  @param[in] array2   the values for array 2
  *  @param[in] array3   the values for array 3
  */
 template < typename Number >


### PR DESCRIPTION
Extending the JINC and JCOH blocks to use arbitrary tabulated data (introduced in MCNPX and the eprdata files for MCNP).

This also adds the SUBSH block to the PhotoatomicTable and adds the first eprdata12 test for it.