### PR TITLE
Feature/catch2 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(ACEtk.python)
   target_compile_options( ACEtk.python PRIVATE "-fvisibility=hidden" )
   set_target_properties( ACEtk.python PROPERTIES OUTPUT_NAME ACEtk )
   set_target_properties( ACEtk.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
-  set_target_properties( ACEtk.python PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties( ACEtk.python PROPERTIES POSITION_INDEPENDENT_CODE ON )
 
   message( STATUS "Building ACEtk's python API" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,6 @@ add_library( ACEtk INTERFACE )
 target_include_directories( ACEtk INTERFACE src/ )
 target_link_libraries( ACEtk
     INTERFACE Log
-    INTERFACE catch-adapter
     INTERFACE disco
     INTERFACE range-v3
     )

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -11,9 +11,9 @@ FetchContent_Declare( Log
     GIT_SHALLOW     TRUE
     )
 
-FetchContent_Declare( catch-adapter
-    GIT_REPOSITORY  https://github.com/njoy/catch-adapter
-    GIT_TAG         origin/master
+FetchContent_Declare( Catch2
+    GIT_REPOSITORY  https://github.com/catchorg/Catch2
+    GIT_TAG         v3.3.2
     GIT_SHALLOW     TRUE
     )
 
@@ -39,7 +39,7 @@ FetchContent_Declare( pybind11
 
 FetchContent_MakeAvailable(
     Log
-    catch-adapter
+    Catch2
     disco
     range-v3
     pybind11

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -10,6 +10,11 @@ FetchContent_Declare( catch-adapter
     GIT_TAG         fb84b82ebf7a4789aa43cea560680cf745c6ee4f
     )
 
+FetchContent_Declare( Catch2
+    GIT_REPOSITORY  https://github.com/catchorg/Catch2
+    GIT_TAG         3f0283de7a9c43200033da996ff9093be3ac84dc # tag: v3.3.2
+    )
+
 FetchContent_Declare( disco
     GIT_REPOSITORY  https://github.com/njoy/disco
     GIT_TAG         2606933a854bb0269c4ec37143e1236797e27838
@@ -41,6 +46,7 @@ FetchContent_Declare( spdlog
 
 FetchContent_MakeAvailable(
     catch-adapter
+    Catch2
     disco
     Log
     pybind11

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -5,11 +5,6 @@ include( FetchContent )
 # Declare project dependencies
 #######################################################################
 
-FetchContent_Declare( catch-adapter
-    GIT_REPOSITORY  https://github.com/njoy/catch-adapter
-    GIT_TAG         fb84b82ebf7a4789aa43cea560680cf745c6ee4f
-    )
-
 FetchContent_Declare( Catch2
     GIT_REPOSITORY  https://github.com/catchorg/Catch2
     GIT_TAG         3f0283de7a9c43200033da996ff9093be3ac84dc # tag: v3.3.2
@@ -45,7 +40,6 @@ FetchContent_Declare( spdlog
 #######################################################################
 
 FetchContent_MakeAvailable(
-    catch-adapter
     Catch2
     disco
     Log

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -5,6 +5,15 @@
 message( STATUS "Adding ACEtk unit testing" )
 enable_testing()
 
+function( add_cpp_test name source )
+
+  set( test_name "ACEtk.${name}.test" )
+  add_executable( ${test_name} ${source} )
+  add_test( NAME ${test_name} COMMAND ${test_name} )
+  target_link_libraries( ${test_name} PRIVATE ACEtk )
+  target_link_libraries( ${test_name} PRIVATE Catch2::Catch2WithMain )
+
+endfunction()
 
 #######################################################################
 # Unit testing directories

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -13,6 +13,11 @@ function( add_cpp_test name source )
   target_link_libraries( ${test_name} PRIVATE ACEtk )
   target_link_libraries( ${test_name} PRIVATE Catch2::Catch2WithMain )
 
+  file( GLOB resources "resources/*" )
+  foreach( resource ${resources})
+      file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
+  endforeach()
+
 endfunction()
 
 #######################################################################

--- a/src/ACEtk/ContinuousEnergyTable/test/CMakeLists.txt
+++ b/src/ACEtk/ContinuousEnergyTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.ContinuousEnergyTable.test ContinuousEnergyTable.test.cpp )
-target_compile_options( ACEtk.ContinuousEnergyTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.ContinuousEnergyTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.ContinuousEnergyTable COMMAND ACEtk.ContinuousEnergyTable.test )
+add_cpp_test( ContinuousEnergyTable ContinuousEnergyTable.test.cpp )

--- a/src/ACEtk/ContinuousEnergyTable/test/ContinuousEnergyTable.test.cpp
+++ b/src/ACEtk/ContinuousEnergyTable/test/ContinuousEnergyTable.test.cpp
@@ -1,10 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/fromFile.hpp"
+// what we are testing
 #include "ACEtk/ContinuousEnergyTable.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -50,7 +53,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -60,7 +63,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -70,7 +73,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -80,7 +83,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -90,7 +93,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -123,7 +126,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -133,7 +136,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -143,7 +146,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -153,7 +156,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -163,7 +166,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -193,7 +196,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -203,7 +206,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -213,7 +216,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -223,7 +226,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -233,7 +236,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -283,7 +286,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -293,7 +296,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -303,7 +306,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -313,7 +316,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -323,7 +326,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -356,7 +359,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -366,7 +369,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -376,7 +379,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -386,7 +389,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -396,7 +399,7 @@ SCENARIO( "ContinuousEnergyTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -413,7 +416,7 @@ SCENARIO( "ContinuousEnergyTable" ){
 void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
 
   CHECK( "92235.710nc" == chunk.ZAID() );
-  CHECK( 2.5301e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.5301e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 837481 == chunk.length() );
   CHECK( 92235 == chunk.ZA() );
@@ -445,11 +448,11 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
   CHECK( 76518 == chunk.ESZ().elastic().size() );
   CHECK( 76518 == chunk.ESZ().heating().size() );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().energies().front() ) );
-  CHECK( 20. == Approx( chunk.ESZ().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().energies().front() ) );
+  CHECK_THAT( 20., WithinRel( chunk.ESZ().energies().back() ) );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().XSS( 1 ) ) );
-  CHECK( 76518 == chunk.ESZ().XSS( 1, chunk.NES() ).size() );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().XSS( 1 ) ) );
+  CHECK_THAT( 20., WithinRel( chunk.ESZ().XSS( 76518 ) ) );
 
   // NU block
   CHECK( false == chunk.NU()->empty() );
@@ -461,17 +464,17 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
 
   CHECK( 0 == prompt.NB() );
   CHECK( 79 == prompt.NE() );
-  CHECK( 1e-11 == Approx( prompt.energies().front() ) );
-  CHECK( 20. == Approx( prompt.energies().back() ) );
-  CHECK( 2.42085 == Approx( prompt.multiplicities().front() ) );
-  CHECK( 5.200845 == Approx( prompt.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( prompt.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( prompt.energies().back() ) );
+  CHECK_THAT( 2.42085, WithinRel( prompt.multiplicities().front() ) );
+  CHECK_THAT( 5.200845, WithinRel( prompt.multiplicities().back() ) );
 
   CHECK( 0 == total.NB() );
   CHECK( 79 == total.NE() );
-  CHECK( 1e-11 == Approx( total.energies().front() ) );
-  CHECK( 20. == Approx( total.energies().back() ) );
-  CHECK( 2.4367 == Approx( total.multiplicities().front() ) );
-  CHECK( 5.209845 == Approx( total.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( total.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( total.energies().back() ) );
+  CHECK_THAT( 2.4367, WithinRel( total.multiplicities().front() ) );
+  CHECK_THAT( 5.209845, WithinRel( total.multiplicities().back() ) );
 
   // MTR block
   CHECK( false == chunk.MTR().empty() );
@@ -534,19 +537,19 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
   CHECK( 76095 == xs48.energyIndex() );
   CHECK( 59 == xs1.numberValues() );
   CHECK( 424 == xs48.numberValues() );
-  CHECK( 0. == Approx( xs1.crossSections().front() ) );
-  CHECK( 1.55512000000E-01 == Approx( xs1.crossSections().back() ) );
-  CHECK( 0. == Approx( xs48.crossSections().front() ) );
-  CHECK( 3.65016600000E-01 == Approx( xs48.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 1.55512000000E-01, WithinRel( xs1.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs48.crossSections().front() ) );
+  CHECK_THAT( 3.65016600000E-01, WithinRel( xs48.crossSections().back() ) );
 
   auto data1 = chunk.SIG().crossSections( 1 );
   auto data48 = chunk.SIG().crossSections( 48 );
   CHECK( 59 == data1.size() );
   CHECK( 424 == data48.size() );
-  CHECK( 0. == Approx( data1.front() ) );
-  CHECK( 1.55512000000E-01 == Approx( data1.back() ) );
-  CHECK( 0. == Approx( data48.front() ) );
-  CHECK( 3.65016600000E-01 == Approx( data48.back() ) );
+  CHECK_THAT( 0., WithinRel( data1.front() ) );
+  CHECK_THAT( 1.55512000000E-01, WithinRel( data1.back() ) );
+  CHECK_THAT( 0., WithinRel( data48.front() ) );
+  CHECK_THAT( 3.65016600000E-01, WithinRel( data48.back() ) );
 
   // AND block
   CHECK( false == chunk.AND().empty() );
@@ -578,8 +581,8 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
   CHECK( false == chunk.GPD()->empty() );
   CHECK( 76518 == chunk.GPD()->totalProduction().size() );
 
-  CHECK( 2.433297E+05 == Approx( chunk.GPD()->totalProduction().front() ) );
-  CHECK( 31.07 == Approx( chunk.GPD()->totalProduction().back() ) );
+  CHECK_THAT( 2.433297E+05, WithinRel( chunk.GPD()->totalProduction().front() ) );
+  CHECK_THAT( 31.07, WithinRel( chunk.GPD()->totalProduction().back() ) );
 
   // MTRP block
   CHECK( false == chunk.MTRP()->empty() );
@@ -664,14 +667,14 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
 
   auto unr1 = chunk.UNR()->probabilityTable( 1 );
   auto unr19 = chunk.UNR()->probabilityTable( 19 );
-  CHECK( 2.25000100000E-03 == Approx( unr1.incidentEnergy() ) );
-  CHECK( 2.49999900000E-02 == Approx( unr19.incidentEnergy() ) );
+  CHECK_THAT( 2.25000100000E-03, WithinRel( unr1.incidentEnergy() ) );
+  CHECK_THAT( 2.49999900000E-02, WithinRel( unr19.incidentEnergy() ) );
   CHECK( 16 == unr1.numberBins() );
   CHECK( 16 == unr19.numberBins() );
-  CHECK( 1. == Approx( unr1.heating().front() ) );
-  CHECK( 1. == Approx( unr1.heating().back() ) );
-  CHECK( 1. == Approx( unr19.heating().front() ) );
-  CHECK( 1. == Approx( unr19.heating().back() ) );
+  CHECK_THAT( 1., WithinRel( unr1.heating().front() ) );
+  CHECK_THAT( 1., WithinRel( unr1.heating().back() ) );
+  CHECK_THAT( 1., WithinRel( unr19.heating().front() ) );
+  CHECK_THAT( 1., WithinRel( unr19.heating().back() ) );
 
   // DNU block
   CHECK( false == chunk.DNU()->empty() );
@@ -682,10 +685,10 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
 
   CHECK( 0 == delayed.NB() );
   CHECK( 6 == delayed.NE() );
-  CHECK( 1e-11 == Approx( delayed.energies().front() ) );
-  CHECK( 20. == Approx( delayed.energies().back() ) );
-  CHECK( 0.01585 == Approx( delayed.multiplicities().front() ) );
-  CHECK( 0.009 == Approx( delayed.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( delayed.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( delayed.energies().back() ) );
+  CHECK_THAT( 0.01585, WithinRel( delayed.multiplicities().front() ) );
+  CHECK_THAT( 0.009, WithinRel( delayed.multiplicities().back() ) );
 
   // BDD block
   CHECK( false == chunk.BDD()->empty() );
@@ -693,8 +696,8 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
   CHECK( 6 == chunk.BDD()->NPCR() );
   CHECK( 6 == chunk.BDD()->numberDelayedPrecursors() );
 
-  CHECK( 1.33360E-10 == Approx( chunk.BDD()->precursorGroupData( 1 ).DEC() ) );
-  CHECK( 2.85300E-08 == Approx( chunk.BDD()->precursorGroupData( 6 ).DEC() ) );
+  CHECK_THAT( 1.33360E-10, WithinRel( chunk.BDD()->precursorGroupData( 1 ).DEC() ) );
+  CHECK_THAT( 2.85300E-08, WithinRel( chunk.BDD()->precursorGroupData( 6 ).DEC() ) );
 
   // DNED block
   CHECK( false == chunk.DNED()->empty() );
@@ -721,7 +724,7 @@ void verifyChunkU235( const ContinuousEnergyTable& chunk ) {
 void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
 
   CHECK( "2003.710nc" == chunk.ZAID() );
-  CHECK( 2.5301e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.5301e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 10004 == chunk.length() );
   CHECK( 2003 == chunk.ZA() );
@@ -753,11 +756,11 @@ void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
   CHECK( 693 == chunk.ESZ().elastic().size() );
   CHECK( 693 == chunk.ESZ().heating().size() );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().energies().front() ) );
-  CHECK( 20. == Approx( chunk.ESZ().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().energies().front() ) );
+  CHECK_THAT( 20., WithinRel( chunk.ESZ().energies().back() ) );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().XSS( 1 ) ) );
-  CHECK( 693 == chunk.ESZ().XSS( 1, chunk.NES() ).size() );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().XSS( 1 ) ) );
+  CHECK_THAT( 20., WithinRel( chunk.ESZ().XSS( 693 ) ) );
 
   // NU block
   CHECK( false == chunk.NU().has_value() );
@@ -804,19 +807,19 @@ void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
   CHECK( 1 == xs8.energyIndex() );
   CHECK( 693 == xs1.numberValues() );
   CHECK( 693 == xs8.numberValues() );
-  CHECK( 2.76519500000E-03 == Approx( xs1.crossSections().front() ) );
-  CHECK( 2.86200000000E-05 == Approx( xs1.crossSections().back() ) );
-  CHECK( 5.36998100000E+02 == Approx( xs8.crossSections().front() ) );
-  CHECK( 2.63996800000E-03 == Approx( xs8.crossSections().back() ) );
+  CHECK_THAT( 2.76519500000E-03, WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 2.86200000000E-05, WithinRel( xs1.crossSections().back() ) );
+  CHECK_THAT( 5.36998100000E+02, WithinRel( xs8.crossSections().front() ) );
+  CHECK_THAT( 2.63996800000E-03, WithinRel( xs8.crossSections().back() ) );
 
   auto data1 = chunk.SIG().crossSections( 1 );
   auto data8 = chunk.SIG().crossSections( 8 );
   CHECK( 693 == data1.size() );
   CHECK( 693 == data8.size() );
-  CHECK( 2.76519500000E-03 == Approx( data1.front() ) );
-  CHECK( 2.86200000000E-05 == Approx( data1.back() ) );
-  CHECK( 5.36998100000E+02 == Approx( data8.front() ) );
-  CHECK( 2.63996800000E-03 == Approx( data8.back() ) );
+  CHECK_THAT( 2.76519500000E-03, WithinRel( data1.front() ) );
+  CHECK_THAT( 2.86200000000E-05, WithinRel( data1.back() ) );
+  CHECK_THAT( 5.36998100000E+02, WithinRel( data8.front() ) );
+  CHECK_THAT( 2.63996800000E-03, WithinRel( data8.back() ) );
 
   // AND block
   CHECK( false == chunk.AND().empty() );
@@ -896,10 +899,10 @@ void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
 
   CHECK( 1 == chunk.HPD(1).energyIndex() );
   CHECK( 693 == chunk.HPD(1).numberValues() );
-  CHECK( 2.76519500000E-03 == Approx( chunk.HPD(1).totalProduction().front() ) );
-  CHECK( 2.86200000000E-05 == Approx( chunk.HPD(1).totalProduction().back() ) );
-  CHECK( 0. == Approx( chunk.HPD(1).heating().front() ) );
-  CHECK( 1.68611800000E-04 == Approx( chunk.HPD(1).heating().back() ) );
+  CHECK_THAT( 2.76519500000E-03, WithinRel( chunk.HPD(1).totalProduction().front() ) );
+  CHECK_THAT( 2.86200000000E-05, WithinRel( chunk.HPD(1).totalProduction().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.HPD(1).heating().front() ) );
+  CHECK_THAT( 1.68611800000E-04, WithinRel( chunk.HPD(1).heating().back() ) );
 
   // MTRH(1) block
   CHECK( false == chunk.MTRH(1).empty() );
@@ -947,12 +950,12 @@ void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
   CHECK( 2 == multiplicity.numberValues() );
 
   CHECK( 2 == multiplicity.energies().size() );
-  CHECK( 1e-5 == Approx( multiplicity.energies().front() ) );
-  CHECK( 20. == Approx( multiplicity.energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( multiplicity.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( multiplicity.energies().back() ) );
 
   CHECK( 2 == multiplicity.multiplicities().size() );
-  CHECK( 1. == Approx( multiplicity.multiplicities().front() ) );
-  CHECK( 1. == Approx( multiplicity.multiplicities().back() ) );
+  CHECK_THAT( 1., WithinRel( multiplicity.multiplicities().front() ) );
+  CHECK_THAT( 1., WithinRel( multiplicity.multiplicities().back() ) );
 
   // ANDH(1) block
   CHECK( false == chunk.ANDH(1).empty() );
@@ -985,7 +988,7 @@ void verifyChunkHe3( const ContinuousEnergyTable& chunk ) {
 void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
 
   CHECK( "92238.69c" == chunk.ZAID() );
-  CHECK( 2.5301e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.5301e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 874492 == chunk.length() );
   CHECK( 92238 == chunk.ZA() );
@@ -1017,11 +1020,11 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
   CHECK( 78709 == chunk.ESZ().elastic().size() );
   CHECK( 78709 == chunk.ESZ().heating().size() );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().energies().front() ) );
-  CHECK( 30. == Approx( chunk.ESZ().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().energies().front() ) );
+  CHECK_THAT( 30., WithinRel( chunk.ESZ().energies().back() ) );
 
-  CHECK( 1e-11 == Approx( chunk.ESZ().XSS( 1 ) ) );
-  CHECK( 78709 == chunk.ESZ().XSS( 1, chunk.NES() ).size() );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ESZ().XSS( 1 ) ) );
+  CHECK_THAT( 30., WithinRel( chunk.ESZ().XSS( 78709 ) ) );
 
   // NU block
   CHECK( false == chunk.NU()->empty() );
@@ -1033,17 +1036,17 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
 
   CHECK( 0 == prompt.NB() );
   CHECK( 6 == prompt.NE() );
-  CHECK( 1e-11 == Approx( prompt.energies().front() ) );
-  CHECK( 30. == Approx( prompt.energies().back() ) );
-  CHECK( 2.448088 == Approx( prompt.multiplicities().front() ) );
-  CHECK( 6.4 == Approx( prompt.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( prompt.energies().front() ) );
+  CHECK_THAT( 30., WithinRel( prompt.energies().back() ) );
+  CHECK_THAT( 2.448088, WithinRel( prompt.multiplicities().front() ) );
+  CHECK_THAT( 6.4, WithinRel( prompt.multiplicities().back() ) );
 
   CHECK( 0 == total.NB() );
   CHECK( 8 == total.NE() );
-  CHECK( 1e-11 == Approx( total.energies().front() ) );
-  CHECK( 30. == Approx( total.energies().back() ) );
-  CHECK( 2.492088 == Approx( total.multiplicities().front() ) );
-  CHECK( 6.426 == Approx( total.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( total.energies().front() ) );
+  CHECK_THAT( 30., WithinRel( total.energies().back() ) );
+  CHECK_THAT( 2.492088, WithinRel( total.multiplicities().front() ) );
+  CHECK_THAT( 6.426, WithinRel( total.multiplicities().back() ) );
 
   // MTR block
   CHECK( false == chunk.MTR().empty() );
@@ -1106,19 +1109,19 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
   CHECK( 1 == xs47.energyIndex() );
   CHECK( 106 == xs1.numberValues() );
   CHECK( 78709 == xs47.numberValues() );
-  CHECK( 0. == Approx( xs1.crossSections().front() ) );
-  CHECK( 1.387829e-1 == Approx( xs1.crossSections().back() ) );
-  CHECK( 6.560634e-4 == Approx( xs47.crossSections().front() ) );
-  CHECK( 3.159912e-1 == Approx( xs47.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 1.387829e-1, WithinRel( xs1.crossSections().back() ) );
+  CHECK_THAT( 6.560634e-4, WithinRel( xs47.crossSections().front() ) );
+  CHECK_THAT( 3.159912e-1, WithinRel( xs47.crossSections().back() ) );
 
   auto data1 = chunk.SIG().crossSections( 1 );
   auto data47 = chunk.SIG().crossSections( 47 );
   CHECK( 106 == data1.size() );
   CHECK( 78709 == data47.size() );
-  CHECK( 0. == Approx( data1.front() ) );
-  CHECK( 1.387829e-1 == Approx( data1.back() ) );
-  CHECK( 6.560634e-4 == Approx( data47.front() ) );
-  CHECK( 3.159912e-1 == Approx( data47.back() ) );
+  CHECK_THAT( 0., WithinRel( data1.front() ) );
+  CHECK_THAT( 1.387829e-1, WithinRel( data1.back() ) );
+  CHECK_THAT( 6.560634e-4, WithinRel( data47.front() ) );
+  CHECK_THAT( 3.159912e-1, WithinRel( data47.back() ) );
 
   // AND block
   CHECK( false == chunk.AND().empty() );
@@ -1152,8 +1155,8 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
   CHECK( false == chunk.GPD()->empty() );
   CHECK( 78709 == chunk.GPD()->totalProduction().size() );
 
-  CHECK( 589.4728 == Approx( chunk.GPD()->totalProduction().front() ) );
-  CHECK( 17.12507 == Approx( chunk.GPD()->totalProduction().back() ) );
+  CHECK_THAT( 589.4728, WithinRel( chunk.GPD()->totalProduction().front() ) );
+  CHECK_THAT( 17.12507, WithinRel( chunk.GPD()->totalProduction().back() ) );
 
   // MTRP block
   CHECK( false == chunk.MTRP()->empty() );
@@ -1236,14 +1239,14 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
 
   auto unr1 = chunk.UNR()->probabilityTable( 1 );
   auto unr23 = chunk.UNR()->probabilityTable( 23 );
-  CHECK( 1.000001E-02 == Approx( unr1.incidentEnergy() ) );
-  CHECK( 1.490287E-01 == Approx( unr23.incidentEnergy() ) );
+  CHECK_THAT( 1.000001E-02, WithinRel( unr1.incidentEnergy() ) );
+  CHECK_THAT( 1.490287E-01, WithinRel( unr23.incidentEnergy() ) );
   CHECK( 20 == unr1.numberBins() );
   CHECK( 20 == unr23.numberBins() );
-  CHECK( 1.12201615476 == Approx( unr1.heating().front() ) );
-  CHECK( .981419270377 == Approx( unr1.heating().back() ) );
-  CHECK( .958067726215 == Approx( unr23.heating().front() ) );
-  CHECK( 1.02349211485 == Approx( unr23.heating().back() ) );
+  CHECK_THAT( 1.12201615476, WithinRel( unr1.heating().front() ) );
+  CHECK_THAT( .981419270377, WithinRel( unr1.heating().back() ) );
+  CHECK_THAT( .958067726215, WithinRel( unr23.heating().front() ) );
+  CHECK_THAT( 1.02349211485, WithinRel( unr23.heating().back() ) );
 
   // DNU block
   CHECK( false == chunk.DNU()->empty() );
@@ -1254,10 +1257,10 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
 
   CHECK( 0 == delayed.NB() );
   CHECK( 4 == delayed.NE() );
-  CHECK( 1e-11 == Approx( delayed.energies().front() ) );
-  CHECK( 30. == Approx( delayed.energies().back() ) );
-  CHECK( 0.044 == Approx( delayed.multiplicities().front() ) );
-  CHECK( 0.026 == Approx( delayed.multiplicities().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( delayed.energies().front() ) );
+  CHECK_THAT( 30., WithinRel( delayed.energies().back() ) );
+  CHECK_THAT( 0.044, WithinRel( delayed.multiplicities().front() ) );
+  CHECK_THAT( 0.026, WithinRel( delayed.multiplicities().back() ) );
 
   // BDD block
   CHECK( false == chunk.BDD()->empty() );
@@ -1265,8 +1268,8 @@ void verifyChunkNJOY99U238( const ContinuousEnergyTable& chunk ) {
   CHECK( 6 == chunk.BDD()->NPCR() );
   CHECK( 6 == chunk.BDD()->numberDelayedPrecursors() );
 
-  CHECK( 1.249817E-10 == Approx( chunk.BDD()->precursorGroupData( 1 ).DEC() ) );
-  CHECK( 4.984604E-08 == Approx( chunk.BDD()->precursorGroupData( 6 ).DEC() ) );
+  CHECK_THAT( 1.249817E-10, WithinRel( chunk.BDD()->precursorGroupData( 1 ).DEC() ) );
+  CHECK_THAT( 4.984604E-08, WithinRel( chunk.BDD()->precursorGroupData( 6 ).DEC() ) );
 
   // DNED block
   CHECK( false == chunk.DNED()->empty() );

--- a/src/ACEtk/DosimetryTable/test/CMakeLists.txt
+++ b/src/ACEtk/DosimetryTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.DosimetryTable.test DosimetryTable.test.cpp )
-target_compile_options( ACEtk.DosimetryTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.DosimetryTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.DosimetryTable COMMAND ACEtk.DosimetryTable.test )
+add_cpp_test( DosimetryTable DosimetryTable.test.cpp )

--- a/src/ACEtk/DosimetryTable/test/DosimetryTable.test.cpp
+++ b/src/ACEtk/DosimetryTable/test/DosimetryTable.test.cpp
@@ -1,10 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/fromFile.hpp"
+// what we are testing
 #include "ACEtk/DosimetryTable.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +44,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -51,7 +54,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -61,7 +64,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -71,7 +74,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -81,7 +84,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -402,7 +405,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -412,7 +415,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -422,7 +425,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -432,7 +435,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -442,7 +445,7 @@ SCENARIO( "DosimetryTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -452,10 +455,10 @@ SCENARIO( "DosimetryTable" ){
 void verifyChunk( const DosimetryTable& chunk ) {
 
   CHECK( "13027.24y" == chunk.ZAID() );
-  CHECK( 26.75 == Approx( chunk.AWR() ) );
-  CHECK( 26.75 == Approx( chunk.atomicWeightRatio() ) );
-  CHECK( 0. == Approx( chunk.TEMP() ) );
-  CHECK( 0. == Approx( chunk.temperature() ) );
+  CHECK_THAT( 26.75, WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 26.75, WithinRel( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 0., WithinRel( chunk.TEMP() ) );
+  CHECK_THAT( 0., WithinRel( chunk.temperature() ) );
 
   CHECK( "" == chunk.date() );
 
@@ -496,12 +499,12 @@ void verifyChunk( const DosimetryTable& chunk ) {
   auto xs2 = chunk.SIGD().crossSectionData( 2 );
   CHECK( 306 == xs1.numberEnergyPoints() );
   CHECK( 272 == xs2.numberEnergyPoints() );
-  CHECK( 1.8961 == Approx( xs1.energies().front() ) );
-  CHECK( 20. == Approx( xs1.energies().back() ) );
-  CHECK( 3.248700000000E+00 == Approx( xs2.energies().front() ) );
-  CHECK( 20. == Approx( xs2.energies().back() ) );
-  CHECK( 0. == Approx( xs1.crossSections().front() ) );
-  CHECK( 0.0322 == Approx( xs1.crossSections().back() ) );
-  CHECK( 0. == Approx( xs2.crossSections().front() ) );
-  CHECK( 0.038 == Approx( xs2.crossSections().back() ) );
+  CHECK_THAT( 1.8961, WithinRel( xs1.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( xs1.energies().back() ) );
+  CHECK_THAT( 3.248700000000E+00, WithinRel( xs2.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( xs2.energies().back() ) );
+  CHECK_THAT( 0., WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 0.0322, WithinRel( xs1.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs2.crossSections().front() ) );
+  CHECK_THAT( 0.038, WithinRel( xs2.crossSections().back() ) );
 }

--- a/src/ACEtk/PhotoatomicTable/test/CMakeLists.txt
+++ b/src/ACEtk/PhotoatomicTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.PhotoatomicTable.test PhotoatomicTable.test.cpp )
-target_compile_options( ACEtk.PhotoatomicTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.PhotoatomicTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.PhotoatomicTable COMMAND ACEtk.PhotoatomicTable.test )
+add_cpp_test( PhotoatomicTable PhotoatomicTable.test.cpp )

--- a/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
+++ b/src/ACEtk/PhotoatomicTable/test/PhotoatomicTable.test.cpp
@@ -1,10 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/fromFile.hpp"
+// what we are testing
 #include "ACEtk/PhotoatomicTable.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +44,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -51,7 +54,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -61,7 +64,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -71,7 +74,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -81,7 +84,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -115,7 +118,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -125,7 +128,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -135,7 +138,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -145,7 +148,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -155,7 +158,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -186,7 +189,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -196,7 +199,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -206,7 +209,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -216,7 +219,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -226,7 +229,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -260,7 +263,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -270,7 +273,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -280,7 +283,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -290,7 +293,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -300,7 +303,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -331,7 +334,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -341,7 +344,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -351,7 +354,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -361,7 +364,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -371,7 +374,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -412,7 +415,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -422,7 +425,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -432,7 +435,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -442,7 +445,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -452,7 +455,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -483,7 +486,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -493,7 +496,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -503,7 +506,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -513,7 +516,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -523,7 +526,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -564,7 +567,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -574,7 +577,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -584,7 +587,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -594,7 +597,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -604,7 +607,7 @@ SCENARIO( "PhotoatomicTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -614,7 +617,7 @@ SCENARIO( "PhotoatomicTable" ){
 void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
 
   CHECK( "1000.01p" == chunk.ZAID() );
-  CHECK( 0. == Approx( chunk.temperature() ) );
+  CHECK_THAT( 0., WithinRel( chunk.temperature() ) );
 
   CHECK( 389 == chunk.length() );
   CHECK( 1 == chunk.Z() );
@@ -658,16 +661,16 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
   CHECK( 43 == chunk.ESZG().photoelectric().size() );
   CHECK( 43 == chunk.ESZG().pairproduction().size() );
 
-  CHECK( -6.907755278982E+00 == Approx( chunk.ESZG().energies().front() ) );
-  CHECK(  4.605170185988E+00 == Approx( chunk.ESZG().energies().back() ) );
-  CHECK( -2.474115088710E+00 == Approx( chunk.ESZG().incoherent().front() ) );
-  CHECK( -4.794460770140E+00 == Approx( chunk.ESZG().incoherent().back() ) );
-  CHECK( -5.438809818403E-01 == Approx( chunk.ESZG().coherent().front() ) );
-  CHECK( -2.149558177385E+01 == Approx( chunk.ESZG().coherent().back() ) );
-  CHECK(  2.449279472145E+00 == Approx( chunk.ESZG().photoelectric().front() ) );
-  CHECK( -2.622629761934E+01 == Approx( chunk.ESZG().photoelectric().back() ) );
-  CHECK(  0.000000000000E+00 == Approx( chunk.ESZG().pairproduction().front() ) );
-  CHECK( -4.455371820900E+00 == Approx( chunk.ESZG().pairproduction().back() ) );
+  CHECK_THAT( -6.907755278982E+00, WithinRel( chunk.ESZG().energies().front() ) );
+  CHECK_THAT(  4.605170185988E+00, WithinRel( chunk.ESZG().energies().back() ) );
+  CHECK_THAT( -2.474115088710E+00, WithinRel( chunk.ESZG().incoherent().front() ) );
+  CHECK_THAT( -4.794460770140E+00, WithinRel( chunk.ESZG().incoherent().back() ) );
+  CHECK_THAT( -5.438809818403E-01, WithinRel( chunk.ESZG().coherent().front() ) );
+  CHECK_THAT( -2.149558177385E+01, WithinRel( chunk.ESZG().coherent().back() ) );
+  CHECK_THAT(  2.449279472145E+00, WithinRel( chunk.ESZG().photoelectric().front() ) );
+  CHECK_THAT( -2.622629761934E+01, WithinRel( chunk.ESZG().photoelectric().back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.ESZG().pairproduction().front() ) );
+  CHECK_THAT( -4.455371820900E+00, WithinRel( chunk.ESZG().pairproduction().back() ) );
 
   // JINC block
   CHECK( false == chunk.JINC().empty() );
@@ -676,12 +679,12 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
   CHECK( 21 == chunk.JINC().numberValues() );
 
   CHECK( 21 == chunk.JINC().momentum().size() );
-  CHECK( 0.   == Approx( chunk.JINC().momentum().front() ) );
-  CHECK( 8.   == Approx( chunk.JINC().momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.JINC().momentum().front() ) );
+  CHECK_THAT( 8.  , WithinRel( chunk.JINC().momentum().back() ) );
 
   CHECK( 21 == chunk.JINC().values().size() );
-  CHECK( 0 == Approx( chunk.JINC().values().front() ) );
-  CHECK( 1 == Approx( chunk.JINC().values().back() ) );
+  CHECK_THAT( 0, WithinRel( chunk.JINC().values().front() ) );
+  CHECK_THAT( 1, WithinRel( chunk.JINC().values().back() ) );
 
   // JCOH block
   CHECK( false == chunk.JCOH().empty() );
@@ -690,16 +693,16 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
   CHECK( 55 == chunk.JCOH().numberValues() );
 
   CHECK( 55 == chunk.JCOH().momentum().size() );
-  CHECK( 0.   == Approx( chunk.JCOH().momentum().front() ) );
-  CHECK( 6.   == Approx( chunk.JCOH().momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.JCOH().momentum().front() ) );
+  CHECK_THAT( 6.  , WithinRel( chunk.JCOH().momentum().back() ) );
 
   CHECK( 55 == chunk.JCOH().integratedFormFactors().size() );
-  CHECK( 0. == Approx( chunk.JCOH().integratedFormFactors().front() ) );
-  CHECK( 3.058316405266E-02 == Approx( chunk.JCOH().integratedFormFactors().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.JCOH().integratedFormFactors().front() ) );
+  CHECK_THAT( 3.058316405266E-02, WithinRel( chunk.JCOH().integratedFormFactors().back() ) );
 
   CHECK( 55 == chunk.JCOH().formFactors().size() );
-  CHECK( 1. == Approx( chunk.JCOH().formFactors().front() ) );
-  CHECK( 6.282390000000E-06 == Approx( chunk.JCOH().formFactors().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.JCOH().formFactors().front() ) );
+  CHECK_THAT( 6.282390000000E-06, WithinRel( chunk.JCOH().formFactors().back() ) );
 
   // JFLO block
   CHECK( false == chunk.JFLO().has_value() );
@@ -711,8 +714,8 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
   CHECK( 43 == chunk.LHNM().numberEnergyPoints() );
   CHECK( 43 == chunk.LHNM().heating().size() );
 
-  CHECK( 9.457315870945E-04 == Approx( chunk.LHNM().heating().front() ) );
-  CHECK( 9.086036433693E+01 == Approx( chunk.LHNM().heating().back() ) );
+  CHECK_THAT( 9.457315870945E-04, WithinRel( chunk.LHNM().heating().front() ) );
+  CHECK_THAT( 9.086036433693E+01, WithinRel( chunk.LHNM().heating().back() ) );
 
   // EPS block
   CHECK( false == chunk.EPS().has_value() );
@@ -753,7 +756,7 @@ void verifyChunkMcplib( const PhotoatomicTable& chunk ) {
 void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
 
   CHECK( "3000.03p" == chunk.ZAID() );
-  CHECK( 0. == Approx( chunk.temperature() ) );
+  CHECK_THAT( 0., WithinRel( chunk.temperature() ) );
 
   CHECK( 821 == chunk.length() );
   CHECK( 3 == chunk.Z() );
@@ -797,16 +800,16 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 82 == chunk.ESZG().photoelectric().size() );
   CHECK( 82 == chunk.ESZG().pairproduction().size() );
 
-  CHECK( -6.907755278982E+00 == Approx( chunk.ESZG().energies().front() ) );
-  CHECK(  1.151292546497E+01 == Approx( chunk.ESZG().energies().back() ) );
-  CHECK( -1.036037569528E+00 == Approx( chunk.ESZG().incoherent().front() ) );
-  CHECK( -9.880667912376E+00 == Approx( chunk.ESZG().incoherent().back() ) );
-  CHECK(  1.556749961755E+00 == Approx( chunk.ESZG().coherent().front() ) );
-  CHECK( -3.192069466597E+01 == Approx( chunk.ESZG().coherent().back() ) );
-  CHECK(  7.753623546560E+00 == Approx( chunk.ESZG().photoelectric().front() ) );
-  CHECK( -2.663665884863E+01 == Approx( chunk.ESZG().photoelectric().back() ) );
-  CHECK(                   0 == Approx( chunk.ESZG().pairproduction().front() ) );
-  CHECK( -2.222019445154E+00 == Approx( chunk.ESZG().pairproduction().back() ) );
+  CHECK_THAT( -6.907755278982E+00, WithinRel( chunk.ESZG().energies().front() ) );
+  CHECK_THAT(  1.151292546497E+01, WithinRel( chunk.ESZG().energies().back() ) );
+  CHECK_THAT( -1.036037569528E+00, WithinRel( chunk.ESZG().incoherent().front() ) );
+  CHECK_THAT( -9.880667912376E+00, WithinRel( chunk.ESZG().incoherent().back() ) );
+  CHECK_THAT(  1.556749961755E+00, WithinRel( chunk.ESZG().coherent().front() ) );
+  CHECK_THAT( -3.192069466597E+01, WithinRel( chunk.ESZG().coherent().back() ) );
+  CHECK_THAT(  7.753623546560E+00, WithinRel( chunk.ESZG().photoelectric().front() ) );
+  CHECK_THAT( -2.663665884863E+01, WithinRel( chunk.ESZG().photoelectric().back() ) );
+  CHECK_THAT(                   0, WithinRel( chunk.ESZG().pairproduction().front() ) );
+  CHECK_THAT( -2.222019445154E+00, WithinRel( chunk.ESZG().pairproduction().back() ) );
 
   // JINC block
   CHECK( false == chunk.JINC().empty() );
@@ -815,12 +818,12 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 21 == chunk.JINC().numberValues() );
 
   CHECK( 21 == chunk.JINC().momentum().size() );
-  CHECK( 0.   == Approx( chunk.JINC().momentum().front() ) );
-  CHECK( 8.   == Approx( chunk.JINC().momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.JINC().momentum().front() ) );
+  CHECK_THAT( 8.  , WithinRel( chunk.JINC().momentum().back() ) );
 
   CHECK( 21 == chunk.JINC().values().size() );
-  CHECK( 0 == Approx( chunk.JINC().values().front() ) );
-  CHECK( 3 == Approx( chunk.JINC().values().back() ) );
+  CHECK_THAT( 0, WithinRel( chunk.JINC().values().front() ) );
+  CHECK_THAT( 3, WithinRel( chunk.JINC().values().back() ) );
 
   // JCOH block
   CHECK( false == chunk.JCOH().empty() );
@@ -829,16 +832,16 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 55 == chunk.JCOH().numberValues() );
 
   CHECK( 55 == chunk.JCOH().momentum().size() );
-  CHECK( 0.   == Approx( chunk.JCOH().momentum().front() ) );
-  CHECK( 6.   == Approx( chunk.JCOH().momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.JCOH().momentum().front() ) );
+  CHECK_THAT( 6.  , WithinRel( chunk.JCOH().momentum().back() ) );
 
   CHECK( 55 == chunk.JCOH().integratedFormFactors().size() );
-  CHECK( 0. == Approx( chunk.JCOH().integratedFormFactors().front() ) );
-  CHECK( 9.972763100947E-02 == Approx( chunk.JCOH().integratedFormFactors().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.JCOH().integratedFormFactors().front() ) );
+  CHECK_THAT( 9.972763100947E-02, WithinRel( chunk.JCOH().integratedFormFactors().back() ) );
 
   CHECK( 55 == chunk.JCOH().formFactors().size() );
-  CHECK( 3. == Approx( chunk.JCOH().formFactors().front() ) );
-  CHECK( 7.806310000000E-04 == Approx( chunk.JCOH().formFactors().back() ) );
+  CHECK_THAT( 3., WithinRel( chunk.JCOH().formFactors().front() ) );
+  CHECK_THAT( 7.806310000000E-04, WithinRel( chunk.JCOH().formFactors().back() ) );
 
   // JFLO block
   CHECK( false == chunk.JFLO().has_value() );
@@ -850,8 +853,8 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 82 == chunk.LHNM().numberEnergyPoints() );
   CHECK( 82 == chunk.LHNM().heating().size() );
 
-  CHECK( 9.978170710722E-04 == Approx( chunk.LHNM().heating().front() ) );
-  CHECK( 9.999428234605E+04 == Approx( chunk.LHNM().heating().back() ) );
+  CHECK_THAT( 9.978170710722E-04, WithinRel( chunk.LHNM().heating().front() ) );
+  CHECK_THAT( 9.999428234605E+04, WithinRel( chunk.LHNM().heating().back() ) );
 
   // EPS block
   CHECK( false == chunk.EPS()->empty() );
@@ -859,19 +862,19 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 2 == chunk.EPS()->NSH() );
   CHECK( 2 == chunk.EPS()->numberElectronShells() );
 
-  CHECK( 2 == Approx( chunk.EPS()->numberElectrons()[0] ) );
-  CHECK( 1 == Approx( chunk.EPS()->numberElectrons()[1] ) );
-  CHECK( 5.480000000000e-05 == Approx( chunk.EPS()->bindingEnergies()[0] ) );
-  CHECK( 1.000000000000e-06 == Approx( chunk.EPS()->bindingEnergies()[1] ) );
-  CHECK( 6.666666666667e-01 == Approx( chunk.EPS()->interactionProbabilities()[0] ) );
-  CHECK( 3.333333333333e-01 == Approx( chunk.EPS()->interactionProbabilities()[1] ) );
+  CHECK_THAT( 2, WithinRel( chunk.EPS()->numberElectrons()[0] ) );
+  CHECK_THAT( 1, WithinRel( chunk.EPS()->numberElectrons()[1] ) );
+  CHECK_THAT( 5.480000000000e-05, WithinRel( chunk.EPS()->bindingEnergies()[0] ) );
+  CHECK_THAT( 1.000000000000e-06, WithinRel( chunk.EPS()->bindingEnergies()[1] ) );
+  CHECK_THAT( 6.666666666667e-01, WithinRel( chunk.EPS()->interactionProbabilities()[0] ) );
+  CHECK_THAT( 3.333333333333e-01, WithinRel( chunk.EPS()->interactionProbabilities()[1] ) );
 
   CHECK( 2 == chunk.EPS()->numberElectronsPerShell( 1 ) );
   CHECK( 1 == chunk.EPS()->numberElectronsPerShell( 2 ) );
-  CHECK( 5.480000000000e-05 == Approx( chunk.EPS()->bindingEnergy( 1 ) ) );
-  CHECK( 1.000000000000e-06 == Approx( chunk.EPS()->bindingEnergy( 2 ) ) );
-  CHECK( 6.666666666667e-01 == Approx( chunk.EPS()->interactionProbability( 1 ) ) );
-  CHECK( 3.333333333333e-01 == Approx( chunk.EPS()->interactionProbability( 2 ) ) );
+  CHECK_THAT( 5.480000000000e-05, WithinRel( chunk.EPS()->bindingEnergy( 1 ) ) );
+  CHECK_THAT( 1.000000000000e-06, WithinRel( chunk.EPS()->bindingEnergy( 2 ) ) );
+  CHECK_THAT( 6.666666666667e-01, WithinRel( chunk.EPS()->interactionProbability( 1 ) ) );
+  CHECK_THAT( 3.333333333333e-01, WithinRel( chunk.EPS()->interactionProbability( 2 ) ) );
 
   // SWD block
   CHECK( false == chunk.SWD()->empty() );
@@ -885,27 +888,27 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 6.527863344596e-01 == Approx( profile.pdf().front() ) );
-  CHECK( 3.571475386101e-10 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 6.527863344596e-01, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 3.571475386101e-10, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   profile = chunk.SWD()->comptonProfile(2);
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 3.848272047027e+00 == Approx( profile.pdf().front() ) );
-  CHECK( 8.728039694288e-12 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 3.848272047027e+00, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 8.728039694288e-12, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   // SUBSH block - not an EPR data file
   CHECK( false == chunk.SUBSH().has_value() );
@@ -940,7 +943,7 @@ void verifyChunkMcplib03( const PhotoatomicTable& chunk ) {
 void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
 
   CHECK( "1000.12p" == chunk.ZAID() );
-  CHECK( 0. == Approx( chunk.temperature() ) );
+  CHECK_THAT( 0., WithinRel( chunk.temperature() ) );
 
   CHECK( 12025 == chunk.length() );
   CHECK( 1 == chunk.Z() );
@@ -984,16 +987,16 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 647 == chunk.ESZG().photoelectric().size() );
   CHECK( 647 == chunk.ESZG().pairproduction().size() );
 
-  CHECK( -1.381551055796E+01 == Approx( chunk.ESZG().energies().front() ) );
-  CHECK(  1.151292546497E+01 == Approx( chunk.ESZG().energies().back() ) );
-  CHECK( -1.616285246005E+01 == Approx( chunk.ESZG().incoherent().front() ) );
-  CHECK( -1.097982967256E+01 == Approx( chunk.ESZG().incoherent().back() ) );
-  CHECK( -1.152423386458E+01 == Approx( chunk.ESZG().coherent().front() ) );
-  CHECK( -3.530963433758E+01 == Approx( chunk.ESZG().coherent().back() ) );
-  CHECK(                   0 == Approx( chunk.ESZG().photoelectric().front() ) );
-  CHECK( -3.249289163676E+01 == Approx( chunk.ESZG().photoelectric().back() ) );
-  CHECK(                   0 == Approx( chunk.ESZG().pairproduction().front() ) );
-  CHECK( -3.877573270699E+00 == Approx( chunk.ESZG().pairproduction().back() ) );
+  CHECK_THAT( -1.381551055796E+01, WithinRel( chunk.ESZG().energies().front() ) );
+  CHECK_THAT(  1.151292546497E+01, WithinRel( chunk.ESZG().energies().back() ) );
+  CHECK_THAT( -1.616285246005E+01, WithinRel( chunk.ESZG().incoherent().front() ) );
+  CHECK_THAT( -1.097982967256E+01, WithinRel( chunk.ESZG().incoherent().back() ) );
+  CHECK_THAT( -1.152423386458E+01, WithinRel( chunk.ESZG().coherent().front() ) );
+  CHECK_THAT( -3.530963433758E+01, WithinRel( chunk.ESZG().coherent().back() ) );
+  CHECK_THAT(                   0, WithinRel( chunk.ESZG().photoelectric().front() ) );
+  CHECK_THAT( -3.249289163676E+01, WithinRel( chunk.ESZG().photoelectric().back() ) );
+  CHECK_THAT(                   0, WithinRel( chunk.ESZG().pairproduction().front() ) );
+  CHECK_THAT( -3.877573270699E+00, WithinRel( chunk.ESZG().pairproduction().back() ) );
 
   // JINC block
   CHECK( false == chunk.JINC().empty() );
@@ -1002,12 +1005,12 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 94 == chunk.JINC().numberValues() );
 
   CHECK( 94 == chunk.JINC().momentum().size() );
-  CHECK( 0.000000000000E+00 == Approx( chunk.JINC().momentum().front() ) );
-  CHECK( 1.000000000000E+09   == Approx( chunk.JINC().momentum().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.JINC().momentum().front() ) );
+  CHECK_THAT( 1.000000000000E+09, WithinRel( chunk.JINC().momentum().back() ) );
 
   CHECK( 94 == chunk.JINC().values().size() );
-  CHECK( 0 == Approx( chunk.JINC().values().front() ) );
-  CHECK( 1 == Approx( chunk.JINC().values().back() ) );
+  CHECK_THAT( 0, WithinRel( chunk.JINC().values().front() ) );
+  CHECK_THAT( 1, WithinRel( chunk.JINC().values().back() ) );
 
   // JCOH block
   CHECK( false == chunk.JCOH().empty() );
@@ -1016,16 +1019,16 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 90 == chunk.JCOH().numberValues() );
 
   CHECK( 90 == chunk.JCOH().momentum().size() );
-  CHECK( 0.                 == Approx( chunk.JCOH().momentum().front() ) );
-  CHECK( 1.000000000000E+09 == Approx( chunk.JCOH().momentum().back() ) );
+  CHECK_THAT( 0.                , WithinRel( chunk.JCOH().momentum().front() ) );
+  CHECK_THAT( 1.000000000000E+09, WithinRel( chunk.JCOH().momentum().back() ) );
 
   CHECK( 90 == chunk.JCOH().integratedFormFactors().size() );
-  CHECK( 0.                 == Approx( chunk.JCOH().integratedFormFactors().front() ) );
-  CHECK( 3.012861887900E-02 == Approx( chunk.JCOH().integratedFormFactors().back() ) );
+  CHECK_THAT( 0.                , WithinRel( chunk.JCOH().integratedFormFactors().front() ) );
+  CHECK_THAT( 3.012861887900E-02, WithinRel( chunk.JCOH().integratedFormFactors().back() ) );
 
   CHECK( 90 == chunk.JCOH().formFactors().size() );
-  CHECK( 1.                 == Approx( chunk.JCOH().formFactors().front() ) );
-  CHECK( 8.182900000000E-39 == Approx( chunk.JCOH().formFactors().back() ) );
+  CHECK_THAT( 1.                , WithinRel( chunk.JCOH().formFactors().front() ) );
+  CHECK_THAT( 8.182900000000E-39, WithinRel( chunk.JCOH().formFactors().back() ) );
 
   // JFLO block
   CHECK( false == chunk.JFLO().has_value() );
@@ -1037,8 +1040,8 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 647 == chunk.LHNM().numberEnergyPoints() );
   CHECK( 647 == chunk.LHNM().heating().size() );
 
-  CHECK( 8.714616354250E-07 == Approx( chunk.LHNM().heating().front() ) );
-  CHECK( 9.999084183050E+04 == Approx( chunk.LHNM().heating().back() ) );
+  CHECK_THAT( 8.714616354250E-07, WithinRel( chunk.LHNM().heating().front() ) );
+  CHECK_THAT( 9.999084183050E+04, WithinRel( chunk.LHNM().heating().back() ) );
 
   // EPS block
   CHECK( false == chunk.EPS()->empty() );
@@ -1046,13 +1049,13 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 1 == chunk.EPS()->NSH() );
   CHECK( 1 == chunk.EPS()->numberElectronShells() );
 
-  CHECK( 1 == Approx( chunk.EPS()->numberElectrons()[0] ) );
-  CHECK( 1.400000000000e-05 == Approx( chunk.EPS()->bindingEnergies()[0] ) );
-  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbabilities()[0] ) );
+  CHECK( 1 == chunk.EPS()->numberElectrons()[0] );
+  CHECK_THAT( 1.400000000000e-05, WithinRel( chunk.EPS()->bindingEnergies()[0] ) );
+  CHECK_THAT( 1.000000000000e+00, WithinRel( chunk.EPS()->interactionProbabilities()[0] ) );
 
   CHECK( 1 == chunk.EPS()->numberElectronsPerShell( 1 ) );
-  CHECK( 1.400000000000e-05 == Approx( chunk.EPS()->bindingEnergy( 1 ) ) );
-  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbability( 1 ) ) );
+  CHECK_THAT( 1.400000000000e-05, WithinRel( chunk.EPS()->bindingEnergy( 1 ) ) );
+  CHECK_THAT( 1.000000000000e+00, WithinRel( chunk.EPS()->interactionProbability( 1 ) ) );
 
   // SWD block
   CHECK( false == chunk.SWD()->empty() );
@@ -1065,14 +1068,14 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 1.690581458877E+00 == Approx( profile.pdf().front() ) );
-  CHECK( 5.177281263934E-11 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 1.690581458877E+00, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 5.177281263934E-11, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   // SUBSH block - EPR data file
   CHECK( true == chunk.SUBSH().has_value() );
@@ -1086,11 +1089,11 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 1 == chunk.SUBSH()->EP()[0] );
   CHECK( 1 == chunk.SUBSH()->populations()[0] );
 
-  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->BE()[0] ) );
-  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->bindingEnergies()[0] ) );
+  CHECK_THAT( 1.361E-05, WithinRel( chunk.SUBSH()->BE()[0] ) );
+  CHECK_THAT( 1.361E-05, WithinRel( chunk.SUBSH()->bindingEnergies()[0] ) );
 
-  CHECK( 1. == Approx( chunk.SUBSH()->CV()[0] ) );
-  CHECK( 1. == Approx( chunk.SUBSH()->vacancyProbabilities()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.SUBSH()->CV()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.SUBSH()->vacancyProbabilities()[0] ) );
 
   CHECK( 0 == chunk.SUBSH()->NT()[0] );
   CHECK( 0 == chunk.SUBSH()->numberTransitions()[0] );
@@ -1099,9 +1102,9 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
 
   CHECK( 1 == chunk.SUBSH()->population( 1 ) );
 
-  CHECK( 1.361E-05 == Approx( chunk.SUBSH()->bindingEnergy( 1 ) ) );
+  CHECK_THAT( 1.361E-05, WithinRel( chunk.SUBSH()->bindingEnergy( 1 ) ) );
 
-  CHECK( 1. == Approx( chunk.SUBSH()->vacancyProbability( 1 ) ) );
+  CHECK_THAT( 1., WithinRel( chunk.SUBSH()->vacancyProbability( 1 ) ) );
 
   CHECK( 0 == chunk.SUBSH()->numberTransitions( 1 ) );
 
@@ -1115,8 +1118,8 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
 
   CHECK( 647 == chunk.SPHEL()->photoelectric(1).size() );
 
-  CHECK(  0.000000000000E+00 == Approx( chunk.SPHEL()->photoelectric(1).front() ) );
-  CHECK( -3.249289163676E+01 == Approx( chunk.SPHEL()->photoelectric(1).back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.SPHEL()->photoelectric(1).front() ) );
+  CHECK_THAT( -3.249289163676E+01, WithinRel( chunk.SPHEL()->photoelectric(1).back() ) );
 
   // XPROB block - EPR data file
   CHECK( true == chunk.XPROB().has_value() );
@@ -1146,20 +1149,20 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 342 == chunk.ESZE()->totalElectroionisation().size() );
   CHECK( 342 == chunk.ESZE()->electroionisation(1).size() );
 
-  CHECK( 1.000000000000E-05 == Approx( chunk.ESZE()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.ESZE()->energies().back() ) );
-  CHECK( 2.748960297832E+08 == Approx( chunk.ESZE()->total().front() ) );
-  CHECK( 1.643349906341E+05 == Approx( chunk.ESZE()->total().back() ) );
-  CHECK( 2.748960000000E+08 == Approx( chunk.ESZE()->elastic().front() ) );
-  CHECK( 1.311760000000E-05 == Approx( chunk.ESZE()->elastic().back() ) );
-  CHECK( 2.978320000000E+01 == Approx( chunk.ESZE()->bremsstrahlung().front() ) );
-  CHECK( 9.906210000000E-01 == Approx( chunk.ESZE()->bremsstrahlung().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.ESZE()->excitation().front() ) );
-  CHECK( 8.144160000000E+04 == Approx( chunk.ESZE()->excitation().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.ESZE()->totalElectroionisation().front() ) );
-  CHECK( 8.289240000000E+04 == Approx( chunk.ESZE()->totalElectroionisation().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.ESZE()->electroionisation(1).front() ) );
-  CHECK( 8.289240000000E+04 == Approx( chunk.ESZE()->electroionisation(1).back() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( chunk.ESZE()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.ESZE()->energies().back() ) );
+  CHECK_THAT( 2.748960297832E+08, WithinRel( chunk.ESZE()->total().front() ) );
+  CHECK_THAT( 1.643349906341E+05, WithinRel( chunk.ESZE()->total().back() ) );
+  CHECK_THAT( 2.748960000000E+08, WithinRel( chunk.ESZE()->elastic().front() ) );
+  CHECK_THAT( 1.311760000000E-05, WithinRel( chunk.ESZE()->elastic().back() ) );
+  CHECK_THAT( 2.978320000000E+01, WithinRel( chunk.ESZE()->bremsstrahlung().front() ) );
+  CHECK_THAT( 9.906210000000E-01, WithinRel( chunk.ESZE()->bremsstrahlung().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.ESZE()->excitation().front() ) );
+  CHECK_THAT( 8.144160000000E+04, WithinRel( chunk.ESZE()->excitation().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.ESZE()->totalElectroionisation().front() ) );
+  CHECK_THAT( 8.289240000000E+04, WithinRel( chunk.ESZE()->totalElectroionisation().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.ESZE()->electroionisation(1).front() ) );
+  CHECK_THAT( 8.289240000000E+04, WithinRel( chunk.ESZE()->electroionisation(1).back() ) );
 
   // EXCIT block - EPR data file
   CHECK( true == chunk.EXCIT().has_value() );
@@ -1170,11 +1173,11 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 170 == chunk.EXCIT()->energies().size() );
   CHECK( 170 == chunk.EXCIT()->excitationEnergyLoss().size() );
 
-  CHECK( 1.361000000000E-05 == Approx( chunk.EXCIT()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.EXCIT()->energies().back() ) );
+  CHECK_THAT( 1.361000000000E-05, WithinRel( chunk.EXCIT()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.EXCIT()->energies().back() ) );
 
-  CHECK( 1.351000000000E-05 == Approx( chunk.EXCIT()->excitationEnergyLoss().front() ) );
-  CHECK( 2.107770000000E-05 == Approx( chunk.EXCIT()->excitationEnergyLoss().back() ) );
+  CHECK_THAT( 1.351000000000E-05, WithinRel( chunk.EXCIT()->excitationEnergyLoss().front() ) );
+  CHECK_THAT( 2.107770000000E-05, WithinRel( chunk.EXCIT()->excitationEnergyLoss().back() ) );
 
   // ELAS block - EPR data file
   CHECK( true == chunk.ELAS().has_value() );
@@ -1188,13 +1191,13 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 1.000000000000E-05 == distribution.energy() );
   CHECK( 3 == distribution.numberCosines() );
 
-  CHECK( -1. == Approx( distribution.cosines()[0] ) );
-  CHECK( 9.9999900000E-01 == Approx( distribution.cosines()[1] ) );
-  CHECK(  1. == Approx( distribution.cosines()[2] ) );
+  CHECK_THAT( -1., WithinRel( distribution.cosines()[0] ) );
+  CHECK_THAT( 9.9999900000E-01, WithinRel( distribution.cosines()[1] ) );
+  CHECK_THAT(  1., WithinRel( distribution.cosines()[2] ) );
 
-  CHECK( 0. == Approx( distribution.cdf()[0] ) );
-  CHECK( 9.9999950000E-01 == Approx( distribution.cdf()[1] ) );
-  CHECK( 1. == Approx( distribution.cdf()[2] ) );
+  CHECK_THAT( 0., WithinRel( distribution.cdf()[0] ) );
+  CHECK_THAT( 9.9999950000E-01, WithinRel( distribution.cdf()[1] ) );
+  CHECK_THAT( 1., WithinRel( distribution.cdf()[2] ) );
 
   distribution = chunk.ELAS()->distribution(16);
   CHECK( 1e+5 == distribution.energy() );
@@ -1209,45 +1212,45 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 8 == chunk.EION( 1 ).distributions().size() );
 
   auto eiondistribution = chunk.EION( 1 ).distribution(1);
-  CHECK( 1.361000000000E-05 == Approx( eiondistribution.energy() ) );
+  CHECK_THAT( 1.361000000000E-05, WithinRel( eiondistribution.energy() ) );
   CHECK( 2 == eiondistribution.numberOutgoingEnergies() );
 
   eiondistribution = chunk.EION( 1 ).distribution(3);
-  CHECK( 1.000000E-04 == Approx( eiondistribution.energy() ) );
+  CHECK_THAT( 1.000000E-04, WithinRel( eiondistribution.energy() ) );
   CHECK( 14 == eiondistribution.numberOutgoingEnergies() );
 
-  CHECK( 1.000000000000E-07 == Approx( eiondistribution.outgoingEnergies()[0] ) );
-  CHECK( 6.309570000000E-07 == Approx( eiondistribution.outgoingEnergies()[1] ) );
-  CHECK( 1.122020000000E-06 == Approx( eiondistribution.outgoingEnergies()[2] ) );
-  CHECK( 1.995260000000E-06 == Approx( eiondistribution.outgoingEnergies()[3] ) );
-  CHECK( 3.162280000000E-06 == Approx( eiondistribution.outgoingEnergies()[4] ) );
-  CHECK( 5.011870000000E-06 == Approx( eiondistribution.outgoingEnergies()[5] ) );
-  CHECK( 6.309580000000E-06 == Approx( eiondistribution.outgoingEnergies()[6] ) );
-  CHECK( 8.912530000000E-06 == Approx( eiondistribution.outgoingEnergies()[7] ) );
-  CHECK( 1.258930000000E-05 == Approx( eiondistribution.outgoingEnergies()[8] ) );
-  CHECK( 1.584900000000E-05 == Approx( eiondistribution.outgoingEnergies()[9] ) );
-  CHECK( 1.883650000000E-05 == Approx( eiondistribution.outgoingEnergies()[10] ) );
-  CHECK( 2.440620000000E-05 == Approx( eiondistribution.outgoingEnergies()[11] ) );
-  CHECK( 3.162280000000E-05 == Approx( eiondistribution.outgoingEnergies()[12] ) );
-  CHECK( 4.319500000000E-05 == Approx( eiondistribution.outgoingEnergies()[13] ) );
+  CHECK_THAT( 1.000000000000E-07, WithinRel( eiondistribution.outgoingEnergies()[0] ) );
+  CHECK_THAT( 6.309570000000E-07, WithinRel( eiondistribution.outgoingEnergies()[1] ) );
+  CHECK_THAT( 1.122020000000E-06, WithinRel( eiondistribution.outgoingEnergies()[2] ) );
+  CHECK_THAT( 1.995260000000E-06, WithinRel( eiondistribution.outgoingEnergies()[3] ) );
+  CHECK_THAT( 3.162280000000E-06, WithinRel( eiondistribution.outgoingEnergies()[4] ) );
+  CHECK_THAT( 5.011870000000E-06, WithinRel( eiondistribution.outgoingEnergies()[5] ) );
+  CHECK_THAT( 6.309580000000E-06, WithinRel( eiondistribution.outgoingEnergies()[6] ) );
+  CHECK_THAT( 8.912530000000E-06, WithinRel( eiondistribution.outgoingEnergies()[7] ) );
+  CHECK_THAT( 1.258930000000E-05, WithinRel( eiondistribution.outgoingEnergies()[8] ) );
+  CHECK_THAT( 1.584900000000E-05, WithinRel( eiondistribution.outgoingEnergies()[9] ) );
+  CHECK_THAT( 1.883650000000E-05, WithinRel( eiondistribution.outgoingEnergies()[10] ) );
+  CHECK_THAT( 2.440620000000E-05, WithinRel( eiondistribution.outgoingEnergies()[11] ) );
+  CHECK_THAT( 3.162280000000E-05, WithinRel( eiondistribution.outgoingEnergies()[12] ) );
+  CHECK_THAT( 4.319500000000E-05, WithinRel( eiondistribution.outgoingEnergies()[13] ) );
 
-  CHECK( 0.000000000000E+00 == Approx( eiondistribution.cdf()[0] ) );
-  CHECK( 7.331561116464E-02 == Approx( eiondistribution.cdf()[1] ) );
-  CHECK( 1.326897983815E-01 == Approx( eiondistribution.cdf()[2] ) );
-  CHECK( 2.239504599538E-01 == Approx( eiondistribution.cdf()[3] ) );
-  CHECK( 3.239408010297E-01 == Approx( eiondistribution.cdf()[4] ) );
-  CHECK( 4.457028360624E-01 == Approx( eiondistribution.cdf()[5] ) );
-  CHECK( 5.121432582477E-01 == Approx( eiondistribution.cdf()[6] ) );
-  CHECK( 6.122427030250E-01 == Approx( eiondistribution.cdf()[7] ) );
-  CHECK( 7.115063101586E-01 == Approx( eiondistribution.cdf()[8] ) );
-  CHECK( 7.742971020638E-01 == Approx( eiondistribution.cdf()[9] ) );
-  CHECK( 8.177487997791E-01 == Approx( eiondistribution.cdf()[10] ) );
-  CHECK( 8.785708761786E-01 == Approx( eiondistribution.cdf()[11] ) );
-  CHECK( 9.338664910728E-01 == Approx( eiondistribution.cdf()[12] ) );
-  CHECK( 1.000000000000E+00 == Approx( eiondistribution.cdf()[13] ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( eiondistribution.cdf()[0] ) );
+  CHECK_THAT( 7.331561116464E-02, WithinRel( eiondistribution.cdf()[1] ) );
+  CHECK_THAT( 1.326897983815E-01, WithinRel( eiondistribution.cdf()[2] ) );
+  CHECK_THAT( 2.239504599538E-01, WithinRel( eiondistribution.cdf()[3] ) );
+  CHECK_THAT( 3.239408010297E-01, WithinRel( eiondistribution.cdf()[4] ) );
+  CHECK_THAT( 4.457028360624E-01, WithinRel( eiondistribution.cdf()[5] ) );
+  CHECK_THAT( 5.121432582477E-01, WithinRel( eiondistribution.cdf()[6] ) );
+  CHECK_THAT( 6.122427030250E-01, WithinRel( eiondistribution.cdf()[7] ) );
+  CHECK_THAT( 7.115063101586E-01, WithinRel( eiondistribution.cdf()[8] ) );
+  CHECK_THAT( 7.742971020638E-01, WithinRel( eiondistribution.cdf()[9] ) );
+  CHECK_THAT( 8.177487997791E-01, WithinRel( eiondistribution.cdf()[10] ) );
+  CHECK_THAT( 8.785708761786E-01, WithinRel( eiondistribution.cdf()[11] ) );
+  CHECK_THAT( 9.338664910728E-01, WithinRel( eiondistribution.cdf()[12] ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( eiondistribution.cdf()[13] ) );
 
   eiondistribution = chunk.EION( 1 ).distribution(8);
-  CHECK( 1e+5 == Approx( eiondistribution.energy() ) );
+  CHECK_THAT( 1e+5, WithinRel( eiondistribution.energy() ) );
   CHECK( 147 == eiondistribution.numberOutgoingEnergies() );
 
   // BREME block - EPR data file
@@ -1259,55 +1262,55 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 10 == chunk.BREME()->distributions().size() );
 
   auto bremdistribution = chunk.BREME()->distribution(1);
-  CHECK( 1.000000000000E-05 == Approx( bremdistribution.energy() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( bremdistribution.energy() ) );
   CHECK( 17 == bremdistribution.numberOutgoingEnergies() );
 
   bremdistribution = chunk.BREME()->distribution(2);
-  CHECK( 2.073600E-05 == Approx( bremdistribution.energy() ) );
+  CHECK_THAT( 2.073600E-05, WithinRel( bremdistribution.energy() ) );
   CHECK( 19 == bremdistribution.numberOutgoingEnergies() );
 
-  CHECK( 1.000000000000E-07 == Approx( bremdistribution.outgoingEnergies()[0] ) );
-  CHECK( 1.460800000000E-07 == Approx( bremdistribution.outgoingEnergies()[1] ) );
-  CHECK( 1.941040000000E-07 == Approx( bremdistribution.outgoingEnergies()[2] ) );
-  CHECK( 2.402240000000E-07 == Approx( bremdistribution.outgoingEnergies()[3] ) );
-  CHECK( 3.307420000000E-07 == Approx( bremdistribution.outgoingEnergies()[4] ) );
-  CHECK( 4.553680000000E-07 == Approx( bremdistribution.outgoingEnergies()[5] ) );
-  CHECK( 6.652010000000E-07 == Approx( bremdistribution.outgoingEnergies()[6] ) );
-  CHECK( 8.838860000000E-07 == Approx( bremdistribution.outgoingEnergies()[7] ) );
-  CHECK( 1.093900000000E-06 == Approx( bremdistribution.outgoingEnergies()[8] ) );
-  CHECK( 1.506090000000E-06 == Approx( bremdistribution.outgoingEnergies()[9] ) );
-  CHECK( 2.073600000000E-06 == Approx( bremdistribution.outgoingEnergies()[10] ) );
-  CHECK( 2.932510000000E-06 == Approx( bremdistribution.outgoingEnergies()[11] ) );
-  CHECK( 4.147200000000E-06 == Approx( bremdistribution.outgoingEnergies()[12] ) );
-  CHECK( 5.865030000000E-06 == Approx( bremdistribution.outgoingEnergies()[13] ) );
-  CHECK( 8.294400000000E-06 == Approx( bremdistribution.outgoingEnergies()[14] ) );
-  CHECK( 1.173010000000E-05 == Approx( bremdistribution.outgoingEnergies()[15] ) );
-  CHECK( 1.658880000000E-05 == Approx( bremdistribution.outgoingEnergies()[16] ) );
-  CHECK( 2.052860000000E-05 == Approx( bremdistribution.outgoingEnergies()[17] ) );
-  CHECK( 2.073600000000E-05 == Approx( bremdistribution.outgoingEnergies()[18] ) );
+  CHECK_THAT( 1.000000000000E-07, WithinRel( bremdistribution.outgoingEnergies()[0] ) );
+  CHECK_THAT( 1.460800000000E-07, WithinRel( bremdistribution.outgoingEnergies()[1] ) );
+  CHECK_THAT( 1.941040000000E-07, WithinRel( bremdistribution.outgoingEnergies()[2] ) );
+  CHECK_THAT( 2.402240000000E-07, WithinRel( bremdistribution.outgoingEnergies()[3] ) );
+  CHECK_THAT( 3.307420000000E-07, WithinRel( bremdistribution.outgoingEnergies()[4] ) );
+  CHECK_THAT( 4.553680000000E-07, WithinRel( bremdistribution.outgoingEnergies()[5] ) );
+  CHECK_THAT( 6.652010000000E-07, WithinRel( bremdistribution.outgoingEnergies()[6] ) );
+  CHECK_THAT( 8.838860000000E-07, WithinRel( bremdistribution.outgoingEnergies()[7] ) );
+  CHECK_THAT( 1.093900000000E-06, WithinRel( bremdistribution.outgoingEnergies()[8] ) );
+  CHECK_THAT( 1.506090000000E-06, WithinRel( bremdistribution.outgoingEnergies()[9] ) );
+  CHECK_THAT( 2.073600000000E-06, WithinRel( bremdistribution.outgoingEnergies()[10] ) );
+  CHECK_THAT( 2.932510000000E-06, WithinRel( bremdistribution.outgoingEnergies()[11] ) );
+  CHECK_THAT( 4.147200000000E-06, WithinRel( bremdistribution.outgoingEnergies()[12] ) );
+  CHECK_THAT( 5.865030000000E-06, WithinRel( bremdistribution.outgoingEnergies()[13] ) );
+  CHECK_THAT( 8.294400000000E-06, WithinRel( bremdistribution.outgoingEnergies()[14] ) );
+  CHECK_THAT( 1.173010000000E-05, WithinRel( bremdistribution.outgoingEnergies()[15] ) );
+  CHECK_THAT( 1.658880000000E-05, WithinRel( bremdistribution.outgoingEnergies()[16] ) );
+  CHECK_THAT( 2.052860000000E-05, WithinRel( bremdistribution.outgoingEnergies()[17] ) );
+  CHECK_THAT( 2.073600000000E-05, WithinRel( bremdistribution.outgoingEnergies()[18] ) );
 
-  CHECK( 0.000000000000E+00 == Approx( bremdistribution.cdf()[0] ) );
-  CHECK( 7.173043318075E-02 == Approx( bremdistribution.cdf()[1] ) );
-  CHECK( 1.249665748251E-01 == Approx( bremdistribution.cdf()[2] ) );
-  CHECK( 1.646566864984E-01 == Approx( bremdistribution.cdf()[3] ) );
-  CHECK( 2.247508182846E-01 == Approx( bremdistribution.cdf()[4] ) );
-  CHECK( 2.848391828607E-01 == Approx( bremdistribution.cdf()[5] ) );
-  CHECK( 3.565273694928E-01 == Approx( bremdistribution.cdf()[6] ) );
-  CHECK( 4.097170294934E-01 == Approx( bremdistribution.cdf()[7] ) );
-  CHECK( 4.493639981010E-01 == Approx( bremdistribution.cdf()[8] ) );
-  CHECK( 5.093809240389E-01 == Approx( bremdistribution.cdf()[9] ) );
-  CHECK( 5.693767769535E-01 == Approx( bremdistribution.cdf()[10] ) );
-  CHECK( 6.345683905906E-01 == Approx( bremdistribution.cdf()[11] ) );
-  CHECK( 6.997311655273E-01 == Approx( bremdistribution.cdf()[12] ) );
-  CHECK( 7.648297087129E-01 == Approx( bremdistribution.cdf()[13] ) );
-  CHECK( 8.298143855346E-01 == Approx( bremdistribution.cdf()[14] ) );
-  CHECK( 8.946128910962E-01 == Approx( bremdistribution.cdf()[15] ) );
-  CHECK( 9.591194227081E-01 == Approx( bremdistribution.cdf()[16] ) );
-  CHECK( 9.981726317539E-01 == Approx( bremdistribution.cdf()[17] ) );
-  CHECK( 1.000000000000E+00 == Approx( bremdistribution.cdf()[18] ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( bremdistribution.cdf()[0] ) );
+  CHECK_THAT( 7.173043318075E-02, WithinRel( bremdistribution.cdf()[1] ) );
+  CHECK_THAT( 1.249665748251E-01, WithinRel( bremdistribution.cdf()[2] ) );
+  CHECK_THAT( 1.646566864984E-01, WithinRel( bremdistribution.cdf()[3] ) );
+  CHECK_THAT( 2.247508182846E-01, WithinRel( bremdistribution.cdf()[4] ) );
+  CHECK_THAT( 2.848391828607E-01, WithinRel( bremdistribution.cdf()[5] ) );
+  CHECK_THAT( 3.565273694928E-01, WithinRel( bremdistribution.cdf()[6] ) );
+  CHECK_THAT( 4.097170294934E-01, WithinRel( bremdistribution.cdf()[7] ) );
+  CHECK_THAT( 4.493639981010E-01, WithinRel( bremdistribution.cdf()[8] ) );
+  CHECK_THAT( 5.093809240389E-01, WithinRel( bremdistribution.cdf()[9] ) );
+  CHECK_THAT( 5.693767769535E-01, WithinRel( bremdistribution.cdf()[10] ) );
+  CHECK_THAT( 6.345683905906E-01, WithinRel( bremdistribution.cdf()[11] ) );
+  CHECK_THAT( 6.997311655273E-01, WithinRel( bremdistribution.cdf()[12] ) );
+  CHECK_THAT( 7.648297087129E-01, WithinRel( bremdistribution.cdf()[13] ) );
+  CHECK_THAT( 8.298143855346E-01, WithinRel( bremdistribution.cdf()[14] ) );
+  CHECK_THAT( 8.946128910962E-01, WithinRel( bremdistribution.cdf()[15] ) );
+  CHECK_THAT( 9.591194227081E-01, WithinRel( bremdistribution.cdf()[16] ) );
+  CHECK_THAT( 9.981726317539E-01, WithinRel( bremdistribution.cdf()[17] ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( bremdistribution.cdf()[18] ) );
 
   bremdistribution = chunk.BREME()->distribution(10);
-  CHECK( 1e+5 == Approx( bremdistribution.energy() ) );
+  CHECK_THAT( 1e+5, WithinRel( bremdistribution.energy() ) );
   CHECK( 111 == bremdistribution.numberOutgoingEnergies() );
 
   // BREML block - EPR data file
@@ -1319,11 +1322,11 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
   CHECK( 82 == chunk.BREML()->energies().size() );
   CHECK( 82 == chunk.BREML()->energyAfterBremsstrahlung().size() );
 
-  CHECK( 1.000000000000E-05 == Approx( chunk.BREML()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.BREML()->energies().back() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( chunk.BREML()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.BREML()->energies().back() ) );
 
-  CHECK( 7.855740000000E-06 == Approx( chunk.BREML()->energyAfterBremsstrahlung().front() ) );
-  CHECK( 9.733190000000E+04 == Approx( chunk.BREML()->energyAfterBremsstrahlung().back() ) );
+  CHECK_THAT( 7.855740000000E-06, WithinRel( chunk.BREML()->energyAfterBremsstrahlung().front() ) );
+  CHECK_THAT( 9.733190000000E+04, WithinRel( chunk.BREML()->energyAfterBremsstrahlung().back() ) );
 
   // SELAS block - not eprdata14 file
   CHECK( false == chunk.SELAS().has_value() );
@@ -1332,7 +1335,7 @@ void verifyChunkEprdata12( const PhotoatomicTable& chunk ) {
 void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
 
   CHECK( "6000.14p" == chunk.ZAID() );
-  CHECK( 0. == Approx( chunk.temperature() ) );
+  CHECK_THAT( 0., WithinRel( chunk.temperature() ) );
 
   CHECK( 24009 == chunk.length() );
   CHECK( 6 == chunk.Z() );
@@ -1376,16 +1379,16 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 1210 == chunk.ESZG().photoelectric().size() );
   CHECK( 1210 == chunk.ESZG().pairproduction().size() );
 
-  CHECK( -1.381551055796E+01 == Approx( chunk.ESZG().energies().front() ) );
-  CHECK(  1.151292546497E+01 == Approx( chunk.ESZG().energies().back() ) );
-  CHECK( -1.508068523402E+01 == Approx( chunk.ESZG().incoherent().front() ) );
-  CHECK( -9.187600885007E+00 == Approx( chunk.ESZG().incoherent().back() ) );
-  CHECK( -9.890915512852E+00 == Approx( chunk.ESZG().coherent().front() ) );
-  CHECK( -3.019653583318E+01 == Approx( chunk.ESZG().coherent().back() ) );
-  CHECK(                   0 == Approx( chunk.ESZG().photoelectric().front() ) );
-  CHECK( -2.312511362096E+01 == Approx( chunk.ESZG().photoelectric().back() ) );
-  CHECK(                   0 == Approx( chunk.ESZG().pairproduction().front() ) );
-  CHECK( -1.024627895579E+00 == Approx( chunk.ESZG().pairproduction().back() ) );
+  CHECK_THAT( -1.381551055796E+01, WithinRel( chunk.ESZG().energies().front() ) );
+  CHECK_THAT(  1.151292546497E+01, WithinRel( chunk.ESZG().energies().back() ) );
+  CHECK_THAT( -1.508068523402E+01, WithinRel( chunk.ESZG().incoherent().front() ) );
+  CHECK_THAT( -9.187600885007E+00, WithinRel( chunk.ESZG().incoherent().back() ) );
+  CHECK_THAT( -9.890915512852E+00, WithinRel( chunk.ESZG().coherent().front() ) );
+  CHECK_THAT( -3.019653583318E+01, WithinRel( chunk.ESZG().coherent().back() ) );
+  CHECK_THAT(                   0, WithinRel( chunk.ESZG().photoelectric().front() ) );
+  CHECK_THAT( -2.312511362096E+01, WithinRel( chunk.ESZG().photoelectric().back() ) );
+  CHECK_THAT(                   0, WithinRel( chunk.ESZG().pairproduction().front() ) );
+  CHECK_THAT( -1.024627895579E+00, WithinRel( chunk.ESZG().pairproduction().back() ) );
 
   // JINC block
   CHECK( false == chunk.JINC().empty() );
@@ -1394,12 +1397,12 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 142 == chunk.JINC().numberValues() );
 
   CHECK( 142 == chunk.JINC().momentum().size() );
-  CHECK( 0.000000000000E+00 == Approx( chunk.JINC().momentum().front() ) );
-  CHECK( 1.000000000000E+09   == Approx( chunk.JINC().momentum().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.JINC().momentum().front() ) );
+  CHECK_THAT( 1.000000000000E+09, WithinRel( chunk.JINC().momentum().back() ) );
 
   CHECK( 142 == chunk.JINC().values().size() );
-  CHECK( 0 == Approx( chunk.JINC().values().front() ) );
-  CHECK( 6 == Approx( chunk.JINC().values().back() ) );
+  CHECK_THAT( 0, WithinRel( chunk.JINC().values().front() ) );
+  CHECK_THAT( 6, WithinRel( chunk.JINC().values().back() ) );
 
   // JCOH block
   CHECK( false == chunk.JCOH().empty() );
@@ -1408,16 +1411,16 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 138 == chunk.JCOH().numberValues() );
 
   CHECK( 138 == chunk.JCOH().momentum().size() );
-  CHECK( 0.                 == Approx( chunk.JCOH().momentum().front() ) );
-  CHECK( 1.000000000000E+09 == Approx( chunk.JCOH().momentum().back() ) );
+  CHECK_THAT( 0.                , WithinRel( chunk.JCOH().momentum().front() ) );
+  CHECK_THAT( 1.000000000000E+09, WithinRel( chunk.JCOH().momentum().back() ) );
 
   CHECK( 138 == chunk.JCOH().integratedFormFactors().size() );
-  CHECK( 0.                 == Approx( chunk.JCOH().integratedFormFactors().front() ) );
-  CHECK( 1.390418232150E-01 == Approx( chunk.JCOH().integratedFormFactors().back() ) );
+  CHECK_THAT( 0.                , WithinRel( chunk.JCOH().integratedFormFactors().front() ) );
+  CHECK_THAT( 1.390418232150E-01, WithinRel( chunk.JCOH().integratedFormFactors().back() ) );
 
   CHECK( 138 == chunk.JCOH().formFactors().size() );
-  CHECK( 6.                 == Approx( chunk.JCOH().formFactors().front() ) );
-  CHECK( 1.681000000000E-29 == Approx( chunk.JCOH().formFactors().back() ) );
+  CHECK_THAT( 6.                , WithinRel( chunk.JCOH().formFactors().front() ) );
+  CHECK_THAT( 1.681000000000E-29, WithinRel( chunk.JCOH().formFactors().back() ) );
 
   // JFLO block
   CHECK( false == chunk.JFLO().has_value() );
@@ -1429,8 +1432,8 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 1210 == chunk.LHNM().numberEnergyPoints() );
   CHECK( 1210 == chunk.LHNM().heating().size() );
 
-  CHECK( 9.318532129105E-07 == Approx( chunk.LHNM().heating().front() ) );
-  CHECK( 9.999615968030E+04 == Approx( chunk.LHNM().heating().back() ) );
+  CHECK_THAT( 9.318532129105E-07, WithinRel( chunk.LHNM().heating().front() ) );
+  CHECK_THAT( 9.999615968030E+04, WithinRel( chunk.LHNM().heating().back() ) );
 
   // EPS block
   CHECK( false == chunk.EPS()->empty() );
@@ -1438,21 +1441,21 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 3 == chunk.EPS()->NSH() );
   CHECK( 3 == chunk.EPS()->numberElectronShells() );
 
-  CHECK( 2 == Approx( chunk.EPS()->numberElectrons()[0] ) );
-  CHECK( 2.847000000000E-04 == Approx( chunk.EPS()->bindingEnergies()[0] ) );
-  CHECK( 3.333333333333E-01 == Approx( chunk.EPS()->interactionProbabilities()[0] ) );
+  CHECK( 2 == chunk.EPS()->numberElectrons()[0] );
+  CHECK_THAT( 2.847000000000E-04, WithinRel( chunk.EPS()->bindingEnergies()[0] ) );
+  CHECK_THAT( 3.333333333333E-01, WithinRel( chunk.EPS()->interactionProbabilities()[0] ) );
 
-  CHECK( 2 == Approx( chunk.EPS()->numberElectrons()[2] ) );
-  CHECK( 0.000000000000e+00 == Approx( chunk.EPS()->bindingEnergies()[2] ) );
-  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbabilities()[2] ) );
+  CHECK( 2 == chunk.EPS()->numberElectrons()[2] );
+  CHECK_THAT( 0.000000000000e+00, WithinRel( chunk.EPS()->bindingEnergies()[2] ) );
+  CHECK_THAT( 1.000000000000e+00, WithinRel( chunk.EPS()->interactionProbabilities()[2] ) );
 
   CHECK( 2 == chunk.EPS()->numberElectronsPerShell( 1 ) );
-  CHECK( 2.847000000000E-04 == Approx( chunk.EPS()->bindingEnergy( 1 ) ) );
-  CHECK( 3.333333333333E-01 == Approx( chunk.EPS()->interactionProbability( 1 ) ) );
+  CHECK_THAT( 2.847000000000E-04, WithinRel( chunk.EPS()->bindingEnergy( 1 ) ) );
+  CHECK_THAT( 3.333333333333E-01, WithinRel( chunk.EPS()->interactionProbability( 1 ) ) );
 
   CHECK( 2 == chunk.EPS()->numberElectronsPerShell( 3 ) );
-  CHECK( 0.000000000000e+00 == Approx( chunk.EPS()->bindingEnergy( 3 ) ) );
-  CHECK( 1.000000000000e+00 == Approx( chunk.EPS()->interactionProbability( 3 ) ) );
+  CHECK_THAT( 0.000000000000e+00, WithinRel( chunk.EPS()->bindingEnergy( 3 ) ) );
+  CHECK_THAT( 1.000000000000e+00, WithinRel( chunk.EPS()->interactionProbability( 3 ) ) );
 
   // SWD block
   CHECK( false == chunk.SWD()->empty() );
@@ -1467,27 +1470,27 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 3.029773669016E-01 == Approx( profile.pdf().front() ) );
-  CHECK( 1.148541652307E-08 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 3.029773669016E-01, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 1.148541652307E-08, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   profile = chunk.SWD()->comptonProfile(3);
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 9.711214568747E-01 == Approx( profile.pdf().front() ) );
-  CHECK( 1.592002388319E-13 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 9.711214568747E-01, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 1.592002388319E-13, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   // SUBSH block - EPR data file
   CHECK( true == chunk.SUBSH().has_value() );
@@ -1513,23 +1516,23 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 0.67 == chunk.SUBSH()->populations()[2] );
   CHECK( 1.33 == chunk.SUBSH()->populations()[3] );
 
-  CHECK( 2.910100000000E-04 == Approx( chunk.SUBSH()->BE()[0] ) );
-  CHECK( 1.756000000000E-05 == Approx( chunk.SUBSH()->BE()[1] ) );
-  CHECK( 8.990000000000E-06 == Approx( chunk.SUBSH()->BE()[2] ) );
-  CHECK( 8.980000000000E-06 == Approx( chunk.SUBSH()->BE()[2] ) );
-  CHECK( 2.910100000000E-04 == Approx( chunk.SUBSH()->bindingEnergies()[0] ) );
-  CHECK( 1.756000000000E-05 == Approx( chunk.SUBSH()->bindingEnergies()[1] ) );
-  CHECK( 8.990000000000E-06 == Approx( chunk.SUBSH()->bindingEnergies()[2] ) );
-  CHECK( 8.980000000000E-06 == Approx( chunk.SUBSH()->bindingEnergies()[3] ) );
+  CHECK_THAT( 2.910100000000E-04, WithinRel( chunk.SUBSH()->BE()[0] ) );
+  CHECK_THAT( 1.756000000000E-05, WithinRel( chunk.SUBSH()->BE()[1] ) );
+  CHECK_THAT( 8.990000000000E-06, WithinRel( chunk.SUBSH()->BE()[2] ) );
+  CHECK_THAT( 8.980000000000E-06, WithinRel( chunk.SUBSH()->BE()[3] ) );
+  CHECK_THAT( 2.910100000000E-04, WithinRel( chunk.SUBSH()->bindingEnergies()[0] ) );
+  CHECK_THAT( 1.756000000000E-05, WithinRel( chunk.SUBSH()->bindingEnergies()[1] ) );
+  CHECK_THAT( 8.990000000000E-06, WithinRel( chunk.SUBSH()->bindingEnergies()[2] ) );
+  CHECK_THAT( 8.980000000000E-06, WithinRel( chunk.SUBSH()->bindingEnergies()[3] ) );
 
-  CHECK( 3.333333333333E-01 == Approx( chunk.SUBSH()->CV()[0] ) );
-  CHECK( 6.666666666667E-01 == Approx( chunk.SUBSH()->CV()[1] ) );
-  CHECK( 7.783333333333E-01 == Approx( chunk.SUBSH()->CV()[2] ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.SUBSH()->CV()[3] ) );
-  CHECK( 3.333333333333E-01 == Approx( chunk.SUBSH()->vacancyProbabilities()[0] ) );
-  CHECK( 6.666666666667E-01 == Approx( chunk.SUBSH()->vacancyProbabilities()[1] ) );
-  CHECK( 7.783333333333E-01 == Approx( chunk.SUBSH()->vacancyProbabilities()[2] ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.SUBSH()->vacancyProbabilities()[3] ) );
+  CHECK_THAT( 3.333333333333E-01, WithinRel( chunk.SUBSH()->CV()[0] ) );
+  CHECK_THAT( 6.666666666667E-01, WithinRel( chunk.SUBSH()->CV()[1] ) );
+  CHECK_THAT( 7.783333333333E-01, WithinRel( chunk.SUBSH()->CV()[2] ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.SUBSH()->CV()[3] ) );
+  CHECK_THAT( 3.333333333333E-01, WithinRel( chunk.SUBSH()->vacancyProbabilities()[0] ) );
+  CHECK_THAT( 6.666666666667E-01, WithinRel( chunk.SUBSH()->vacancyProbabilities()[1] ) );
+  CHECK_THAT( 7.783333333333E-01, WithinRel( chunk.SUBSH()->vacancyProbabilities()[2] ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.SUBSH()->vacancyProbabilities()[3] ) );
 
   CHECK( 8 == chunk.SUBSH()->NT()[0] );
   CHECK( 0 == chunk.SUBSH()->NT()[1] );
@@ -1544,13 +1547,13 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 4 == chunk.SUBSH()->designator( 4 ) );
 
   CHECK( 2 == chunk.SUBSH()->population( 1 ) );
-  CHECK( 1.33 == Approx( chunk.SUBSH()->population( 4 ) ) );
+  CHECK_THAT( 1.33, WithinRel( chunk.SUBSH()->population( 4 ) ) );
 
-  CHECK( 2.910100000000E-04 == Approx( chunk.SUBSH()->bindingEnergy( 1 ) ) );
-  CHECK( 8.980000000000E-06 == Approx( chunk.SUBSH()->bindingEnergy( 4 ) ) );
+  CHECK_THAT( 2.910100000000E-04, WithinRel( chunk.SUBSH()->bindingEnergy( 1 ) ) );
+  CHECK_THAT( 8.980000000000E-06, WithinRel( chunk.SUBSH()->bindingEnergy( 4 ) ) );
 
-  CHECK( 3.333333333333E-01 == Approx( chunk.SUBSH()->vacancyProbability( 1 ) ) );
-  CHECK( 1. == Approx( chunk.SUBSH()->vacancyProbability( 4 ) ) );
+  CHECK_THAT( 3.333333333333E-01, WithinRel( chunk.SUBSH()->vacancyProbability( 1 ) ) );
+  CHECK_THAT( 1., WithinRel( chunk.SUBSH()->vacancyProbability( 4 ) ) );
 
   CHECK( 8 == chunk.SUBSH()->numberTransitions( 1 ) );
   CHECK( 0 == chunk.SUBSH()->numberTransitions( 4 ) );
@@ -1568,14 +1571,14 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 1210 == chunk.SPHEL()->photoelectric(3).size() );
   CHECK( 1210 == chunk.SPHEL()->photoelectric(4).size() );
 
-  CHECK(  0.000000000000E+00 == Approx( chunk.SPHEL()->photoelectric(1).front() ) );
-  CHECK( -2.317697619097E+01 == Approx( chunk.SPHEL()->photoelectric(1).back() ) );
-  CHECK(  0.000000000000E+00 == Approx( chunk.SPHEL()->photoelectric(2).front() ) );
-  CHECK( -2.611037070231E+01 == Approx( chunk.SPHEL()->photoelectric(2).back() ) );
-  CHECK(  0.000000000000E+00 == Approx( chunk.SPHEL()->photoelectric(3).front() ) );
-  CHECK( -3.548663519625E+01 == Approx( chunk.SPHEL()->photoelectric(3).back() ) );
-  CHECK(  0.000000000000E+00 == Approx( chunk.SPHEL()->photoelectric(4).front() ) );
-  CHECK( -3.465159800880E+01 == Approx( chunk.SPHEL()->photoelectric(4).back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.SPHEL()->photoelectric(1).front() ) );
+  CHECK_THAT( -2.317697619097E+01, WithinRel( chunk.SPHEL()->photoelectric(1).back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.SPHEL()->photoelectric(2).front() ) );
+  CHECK_THAT( -2.611037070231E+01, WithinRel( chunk.SPHEL()->photoelectric(2).back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.SPHEL()->photoelectric(3).front() ) );
+  CHECK_THAT( -3.548663519625E+01, WithinRel( chunk.SPHEL()->photoelectric(3).back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.SPHEL()->photoelectric(4).front() ) );
+  CHECK_THAT( -3.465159800880E+01, WithinRel( chunk.SPHEL()->photoelectric(4).back() ) );
 
   // XPROB block - EPR data file
   CHECK( true == chunk.XPROB().has_value() );
@@ -1599,23 +1602,23 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 4 == chunk.XPROB()->transitionData(1).transition(1).size() );
   CHECK( 4 == chunk.XPROB()->transitionData(1).transition(8).size() );
 
-  CHECK( 3 == Approx( chunk.XPROB()->transitionData(1).transition(1)[0] ) );
-  CHECK( 0 == Approx( chunk.XPROB()->transitionData(1).transition(1)[1] ) );
-  CHECK( 2.820200000000E-04 == Approx( chunk.XPROB()->transitionData(1).transition(1)[2] ) );
-  CHECK( 5.614877933725E-04 == Approx( chunk.XPROB()->transitionData(1).transition(1)[3] ) );
-  CHECK( 4 == Approx( chunk.XPROB()->transitionData(1).transition(8)[0] ) );
-  CHECK( 4 == Approx( chunk.XPROB()->transitionData(1).transition(8)[1] ) );
-  CHECK( 2.730500000000E-04 == Approx( chunk.XPROB()->transitionData(1).transition(8)[2] ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.XPROB()->transitionData(1).transition(8)[3] ) );
+  CHECK_THAT( 3, WithinRel( chunk.XPROB()->transitionData(1).transition(1)[0] ) );
+  CHECK_THAT( 0, WithinRel( chunk.XPROB()->transitionData(1).transition(1)[1] ) );
+  CHECK_THAT( 2.820200000000E-04, WithinRel( chunk.XPROB()->transitionData(1).transition(1)[2] ) );
+  CHECK_THAT( 5.614877933725E-04, WithinRel( chunk.XPROB()->transitionData(1).transition(1)[3] ) );
+  CHECK_THAT( 4, WithinRel( chunk.XPROB()->transitionData(1).transition(8)[0] ) );
+  CHECK_THAT( 4, WithinRel( chunk.XPROB()->transitionData(1).transition(8)[1] ) );
+  CHECK_THAT( 2.730500000000E-04, WithinRel( chunk.XPROB()->transitionData(1).transition(8)[2] ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.XPROB()->transitionData(1).transition(8)[3] ) );
 
   CHECK( 3 == chunk.XPROB()->transitionData(1).primaryDesignator(1) );
   CHECK( 0 == chunk.XPROB()->transitionData(1).secondaryDesignator(1) );
-  CHECK( 2.820200000000E-04 == Approx( chunk.XPROB()->transitionData(1).energy(1) ) );
-  CHECK( 5.614877933725E-04 == Approx( chunk.XPROB()->transitionData(1).probability(1) ) );
+  CHECK_THAT( 2.820200000000E-04, WithinRel( chunk.XPROB()->transitionData(1).energy(1) ) );
+  CHECK_THAT( 5.614877933725E-04, WithinRel( chunk.XPROB()->transitionData(1).probability(1) ) );
   CHECK( 4 == chunk.XPROB()->transitionData(1).primaryDesignator(8) );
   CHECK( 4 == chunk.XPROB()->transitionData(1).secondaryDesignator(8) );
-  CHECK( 2.730500000000E-04 == Approx( chunk.XPROB()->transitionData(1).energy(8) ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.XPROB()->transitionData(1).probability(8) ) );
+  CHECK_THAT( 2.730500000000E-04, WithinRel( chunk.XPROB()->transitionData(1).energy(8) ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.XPROB()->transitionData(1).probability(8) ) );
 
   CHECK( true == chunk.XPROB()->transitionData(1).isRadiativeTransition(1) );
   CHECK( false == chunk.XPROB()->transitionData(1).isRadiativeTransition(8) );
@@ -1643,26 +1646,26 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 352 == chunk.ESZE()->electroionisation(3).size() );
   CHECK( 352 == chunk.ESZE()->electroionisation(4).size() );
 
-  CHECK( 1.000000000000E-05 == Approx( chunk.ESZE()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.ESZE()->energies().back() ) );
-  CHECK( 3.098128233128E+09 == Approx( chunk.ESZE()->total().front() ) );
-  CHECK( 5.118768719723E+05 == Approx( chunk.ESZE()->total().back() ) );
-  CHECK( 3.063510000000E+09 == Approx( chunk.ESZE()->elastic().front() ) );
-  CHECK( 4.723090000000E-04 == Approx( chunk.ESZE()->elastic().back() ) );
-  CHECK( 6.031280000000E+02 == Approx( chunk.ESZE()->bremsstrahlung().front() ) );
-  CHECK( 1.697150000000E+01 == Approx( chunk.ESZE()->bremsstrahlung().back() ) );
-  CHECK( 3.168630000000E+06 == Approx( chunk.ESZE()->excitation().front() ) );
-  CHECK( 1.198920000000E+05 == Approx( chunk.ESZE()->excitation().back() ) );
-  CHECK( 3.144900000000E+07 == Approx( chunk.ESZE()->totalElectroionisation().front() ) );
-  CHECK( 3.919679000000E+05 == Approx( chunk.ESZE()->totalElectroionisation().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.ESZE()->electroionisation(1).front() ) );
-  CHECK( 1.338050000000E+04 == Approx( chunk.ESZE()->electroionisation(1).back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.ESZE()->electroionisation(2).front() ) );
-  CHECK( 7.595140000000E+04 == Approx( chunk.ESZE()->electroionisation(2).back() ) );
-  CHECK( 1.041970000000E+07 == Approx( chunk.ESZE()->electroionisation(3).front() ) );
-  CHECK( 1.009350000000E+05 == Approx( chunk.ESZE()->electroionisation(3).back() ) );
-  CHECK( 2.102930000000E+07 == Approx( chunk.ESZE()->electroionisation(4).front() ) );
-  CHECK( 2.017010000000E+05 == Approx( chunk.ESZE()->electroionisation(4).back() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( chunk.ESZE()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.ESZE()->energies().back() ) );
+  CHECK_THAT( 3.098128233128E+09, WithinRel( chunk.ESZE()->total().front() ) );
+  CHECK_THAT( 5.118768719723E+05, WithinRel( chunk.ESZE()->total().back() ) );
+  CHECK_THAT( 3.063510000000E+09, WithinRel( chunk.ESZE()->elastic().front() ) );
+  CHECK_THAT( 4.723090000000E-04, WithinRel( chunk.ESZE()->elastic().back() ) );
+  CHECK_THAT( 6.031280000000E+02, WithinRel( chunk.ESZE()->bremsstrahlung().front() ) );
+  CHECK_THAT( 1.697150000000E+01, WithinRel( chunk.ESZE()->bremsstrahlung().back() ) );
+  CHECK_THAT( 3.168630000000E+06, WithinRel( chunk.ESZE()->excitation().front() ) );
+  CHECK_THAT( 1.198920000000E+05, WithinRel( chunk.ESZE()->excitation().back() ) );
+  CHECK_THAT( 3.144900000000E+07, WithinRel( chunk.ESZE()->totalElectroionisation().front() ) );
+  CHECK_THAT( 3.919679000000E+05, WithinRel( chunk.ESZE()->totalElectroionisation().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.ESZE()->electroionisation(1).front() ) );
+  CHECK_THAT( 1.338050000000E+04, WithinRel( chunk.ESZE()->electroionisation(1).back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.ESZE()->electroionisation(2).front() ) );
+  CHECK_THAT( 7.595140000000E+04, WithinRel( chunk.ESZE()->electroionisation(2).back() ) );
+  CHECK_THAT( 1.041970000000E+07, WithinRel( chunk.ESZE()->electroionisation(3).front() ) );
+  CHECK_THAT( 1.009350000000E+05, WithinRel( chunk.ESZE()->electroionisation(3).back() ) );
+  CHECK_THAT( 2.102930000000E+07, WithinRel( chunk.ESZE()->electroionisation(4).front() ) );
+  CHECK_THAT( 2.017010000000E+05, WithinRel( chunk.ESZE()->electroionisation(4).back() ) );
 
   // EXCIT block - EPR data file
   CHECK( true == chunk.EXCIT().has_value() );
@@ -1673,11 +1676,11 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 181 == chunk.EXCIT()->energies().size() );
   CHECK( 181 == chunk.EXCIT()->excitationEnergyLoss().size() );
 
-  CHECK( 1.000000000000E-05 == Approx( chunk.EXCIT()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.EXCIT()->energies().back() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( chunk.EXCIT()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.EXCIT()->energies().back() ) );
 
-  CHECK( 9.232690000000E-06 == Approx( chunk.EXCIT()->excitationEnergyLoss().front() ) );
-  CHECK( 1.981540000000E-05 == Approx( chunk.EXCIT()->excitationEnergyLoss().back() ) );
+  CHECK_THAT( 9.232690000000E-06, WithinRel( chunk.EXCIT()->excitationEnergyLoss().front() ) );
+  CHECK_THAT( 1.981540000000E-05, WithinRel( chunk.EXCIT()->excitationEnergyLoss().back() ) );
 
   // ELAS block - EPR data file
   CHECK( true == chunk.ELAS().has_value() );
@@ -1747,11 +1750,11 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 75 == chunk.BREML()->energies().size() );
   CHECK( 75 == chunk.BREML()->energyAfterBremsstrahlung().size() );
 
-  CHECK( 1.000000000000E-05 == Approx( chunk.BREML()->energies().front() ) );
-  CHECK( 1.000000000000E+05 == Approx( chunk.BREML()->energies().back() ) );
+  CHECK_THAT( 1.000000000000E-05, WithinRel( chunk.BREML()->energies().front() ) );
+  CHECK_THAT( 1.000000000000E+05, WithinRel( chunk.BREML()->energies().back() ) );
 
-  CHECK( 2.150380000000E-06 == Approx( chunk.BREML()->energyAfterBremsstrahlung().front() ) );
-  CHECK( 2.712000000000E+03 == Approx( chunk.BREML()->energyAfterBremsstrahlung().back() ) );
+  CHECK_THAT( 2.150380000000E-06, WithinRel( chunk.BREML()->energyAfterBremsstrahlung().front() ) );
+  CHECK_THAT( 2.712000000000E+03, WithinRel( chunk.BREML()->energyAfterBremsstrahlung().back() ) );
 
   // SELAS block - EPR data file
   CHECK( true == chunk.SELAS().has_value() );
@@ -1762,9 +1765,9 @@ void verifyChunkEprdata14( const PhotoatomicTable& chunk ) {
   CHECK( 352 == chunk.SELAS()->transport().size() );
   CHECK( 352 == chunk.SELAS()->total().size() );
 
-  CHECK( 3.063510000000E+09 == Approx( chunk.SELAS()->transport().front() ) );
-  CHECK( 1.510140000000E-08 == Approx( chunk.SELAS()->transport().back() ) );
+  CHECK_THAT( 3.063510000000E+09, WithinRel( chunk.SELAS()->transport().front() ) );
+  CHECK_THAT( 1.510140000000E-08, WithinRel( chunk.SELAS()->transport().back() ) );
 
-  CHECK( 3.063510000000E+09 == Approx( chunk.SELAS()->total().front() ) );
-  CHECK( 1.407220000000E+05 == Approx( chunk.SELAS()->total().back() ) );
+  CHECK_THAT( 3.063510000000E+09, WithinRel( chunk.SELAS()->total().front() ) );
+  CHECK_THAT( 1.407220000000E+05, WithinRel( chunk.SELAS()->total().back() ) );
 }

--- a/src/ACEtk/PhotonuclearTable/test/CMakeLists.txt
+++ b/src/ACEtk/PhotonuclearTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.PhotonuclearTable.test PhotonuclearTable.test.cpp )
-target_compile_options( ACEtk.PhotonuclearTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.PhotonuclearTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.PhotonuclearTable COMMAND ACEtk.PhotonuclearTable.test )
+add_cpp_test( PhotonuclearTable PhotonuclearTable.test.cpp )

--- a/src/ACEtk/PhotonuclearTable/test/PhotonuclearTable.test.cpp
+++ b/src/ACEtk/PhotonuclearTable/test/PhotonuclearTable.test.cpp
@@ -1,10 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/fromFile.hpp"
+// what we are testing
 #include "ACEtk/PhotonuclearTable.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -40,7 +43,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -50,7 +53,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -60,7 +63,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -70,7 +73,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -80,7 +83,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -126,7 +129,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -136,7 +139,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -146,7 +149,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -156,7 +159,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -166,7 +169,7 @@ SCENARIO( "PhotonuclearTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -176,7 +179,7 @@ SCENARIO( "PhotonuclearTable" ){
 void verifyChunk( const PhotonuclearTable& chunk ) {
 
   CHECK( "94239.31u" == chunk.ZAID() );
-  CHECK( 0.0 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 0.0, WithinRel( chunk.temperature() ) );
 
   CHECK( 1038009 == chunk.length() );
   CHECK( 94239 == chunk.ZA() );
@@ -194,11 +197,11 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   CHECK( 0 == chunk.ESZ().elastic().size() );
   CHECK( 90 == chunk.ESZ().heating().size() );
 
-  CHECK( 1. == Approx( chunk.ESZ().energies().front() ) );
-  CHECK( 200. == Approx( chunk.ESZ().energies().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.ESZ().energies().front() ) );
+  CHECK_THAT( 200., WithinRel( chunk.ESZ().energies().back() ) );
 
-  CHECK( 1. == Approx( chunk.ESZ().XSS( 1 ) ) );
-  CHECK( 90 == chunk.ESZ().XSS( 1, chunk.NES() ).size() );
+  CHECK_THAT( 1., WithinRel( chunk.ESZ().XSS( 1 ) ) );
+  CHECK_THAT( 200., WithinRel( chunk.ESZ().XSS( 90 ) ) );
 
   // MTR block
   CHECK( false == chunk.MTR().empty() );
@@ -222,11 +225,11 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   // LQR block
   CHECK( false == chunk.LQR().empty() );
   CHECK( 2 == chunk.LQR().QValues().size() );
-  CHECK( 0. == chunk.LQR().QValues().front() );
-  CHECK( 199.188 == Approx( chunk.LQR().QValues().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.LQR().QValues().front() ) );
+  CHECK_THAT( 199.188, WithinRel( chunk.LQR().QValues().back() ) );
 
-  CHECK( 0. == chunk.LQR().QValue( 1 ) );
-  CHECK( 199.188 == Approx( chunk.LQR().QValue( 2 ) ) );
+  CHECK_THAT( 0., WithinRel( chunk.LQR().QValue( 1 ) ) );
+  CHECK_THAT( 199.188, WithinRel( chunk.LQR().QValue( 2 ) ) );
 
   // SIG block
   CHECK( false == chunk.SIG().empty() );
@@ -247,19 +250,19 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   CHECK( 3 == xs2.energyIndex() );
   CHECK( 90 == xs1.numberValues() );
   CHECK( 88 == xs2.numberValues() );
-  CHECK( 0. == Approx( xs1.crossSections().front() ) );
-  CHECK( 3.35584000000E-04 == Approx( xs1.crossSections().back() ) );
-  CHECK( 0. == Approx( xs2.crossSections().front() ) );
-  CHECK( 6.65666700000E-03 == Approx( xs2.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 3.35584000000E-04, WithinRel( xs1.crossSections().back() ) );
+  CHECK_THAT( 0., WithinRel( xs2.crossSections().front() ) );
+  CHECK_THAT( 6.65666700000E-03, WithinRel( xs2.crossSections().back() ) );
 
   auto data1 = chunk.SIG().crossSections( 1 );
   auto data2 = chunk.SIG().crossSections( 2 );
   CHECK( 90 == data1.size() );
   CHECK( 88 == data2.size() );
-  CHECK( 0. == Approx( data1.front() ) );
-  CHECK( 3.35584000000E-04 == Approx( data1.back() ) );
-  CHECK( 0. == Approx( data2.front() ) );
-  CHECK( 6.65666700000E-03 == Approx( data2.back() ) );
+  CHECK_THAT( 0., WithinRel( data1.front() ) );
+  CHECK_THAT( 3.35584000000E-04, WithinRel( data1.back() ) );
+  CHECK_THAT( 0., WithinRel( data2.front() ) );
+  CHECK_THAT( 6.65666700000E-03, WithinRel( data2.back() ) );
 
   // IXSU block
   CHECK( false == chunk.IXS()->empty() );
@@ -310,16 +313,16 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
 
   CHECK( 1 == chunk.PXS(1).energyIndex() );
   CHECK( 90 == chunk.PXS(1).numberValues() );
-  CHECK( 0.00000000000E+00 == Approx( chunk.PXS(1).crossSections().front() ) );
-  CHECK( 1.21479700000E-01 == Approx( chunk.PXS(1).crossSections().back() ) );
+  CHECK_THAT( 0.00000000000E+00, WithinRel( chunk.PXS(1).crossSections().front() ) );
+  CHECK_THAT( 1.21479700000E-01, WithinRel( chunk.PXS(1).crossSections().back() ) );
 
   // PHN(1) block
   CHECK( false == chunk.PHN(1).empty() );
 
   CHECK( 1 == chunk.PHN(1).energyIndex() );
   CHECK( 90 == chunk.PHN(1).numberValues() );
-  CHECK( 0.00000000000E+00 == Approx( chunk.PHN(1).crossSections().front() ) );
-  CHECK( 7.91132000000E+01 == Approx( chunk.PHN(1).crossSections().back() ) );
+  CHECK_THAT( 0.00000000000E+00, WithinRel( chunk.PHN(1).crossSections().front() ) );
+  CHECK_THAT( 7.91132000000E+01, WithinRel( chunk.PHN(1).crossSections().back() ) );
 
   // MTRH(1) block
   CHECK( false == chunk.MTRH(1).empty() );
@@ -353,12 +356,12 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   CHECK( 84 == multiplicity.numberValues() );
 
   CHECK( 84 == multiplicity.energies().size() );
-  CHECK( 1.00000000000E+00 == Approx( multiplicity.energies().front() ) );
-  CHECK( 2.00000000000E+02 == Approx( multiplicity.energies().back() ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( multiplicity.energies().front() ) );
+  CHECK_THAT( 2.00000000000E+02, WithinRel( multiplicity.energies().back() ) );
 
   CHECK( 84 == multiplicity.multiplicities().size() );
-  CHECK( 0.00000000000E+00 == Approx( multiplicity.multiplicities().front() ) );
-  CHECK( 1.26229500000E+02 == Approx( multiplicity.multiplicities().back() ) );
+  CHECK_THAT( 0.00000000000E+00, WithinRel( multiplicity.multiplicities().front() ) );
+  CHECK_THAT( 1.26229500000E+02, WithinRel( multiplicity.multiplicities().back() ) );
 
   multiplicity = chunk.SIGH(1).crossSectionData( 2 );
   CHECK( 6 == multiplicity.MFTYPE() );
@@ -372,12 +375,12 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   CHECK( 88 == multiplicity.numberValues() );
 
   CHECK( 88 == multiplicity.energies().size() );
-  CHECK( 1.00000000000E+00 == Approx( multiplicity.energies().front() ) );
-  CHECK( 2.00000000000E+02 == Approx( multiplicity.energies().back() ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( multiplicity.energies().front() ) );
+  CHECK_THAT( 2.00000000000E+02, WithinRel( multiplicity.energies().back() ) );
 
   CHECK( 88 == multiplicity.multiplicities().size() );
-  CHECK( 1.94030000000E+00 == Approx( multiplicity.multiplicities().front() ) );
-  CHECK( 1.18857000000E+01 == Approx( multiplicity.multiplicities().back() ) );
+  CHECK_THAT( 1.94030000000E+00, WithinRel( multiplicity.multiplicities().front() ) );
+  CHECK_THAT( 1.18857000000E+01, WithinRel( multiplicity.multiplicities().back() ) );
 
   // ANDH(1) block
   CHECK( false == chunk.ANDH(1).empty() );
@@ -398,16 +401,16 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
 
   CHECK( 1 == chunk.PXS(7).energyIndex() );
   CHECK( 90 == chunk.PXS(7).numberValues() );
-  CHECK( 0.00000000000E+00 == Approx( chunk.PXS(7).crossSections().front() ) );
-  CHECK( 1.63503800000E-03 == Approx( chunk.PXS(7).crossSections().back() ) );
+  CHECK_THAT( 0.00000000000E+00, WithinRel( chunk.PXS(7).crossSections().front() ) );
+  CHECK_THAT( 1.63503800000E-03, WithinRel( chunk.PXS(7).crossSections().back() ) );
 
   // PHN(7) block
   CHECK( false == chunk.PHN(7).empty() );
 
   CHECK( 1 == chunk.PHN(7).energyIndex() );
   CHECK( 90 == chunk.PHN(7).numberValues() );
-  CHECK( 0.00000000000E+00 == Approx( chunk.PHN(7).crossSections().front() ) );
-  CHECK( 5.97042200000E+00 == Approx( chunk.PHN(7).crossSections().back() ) );
+  CHECK_THAT( 0.00000000000E+00, WithinRel( chunk.PHN(7).crossSections().front() ) );
+  CHECK_THAT( 5.97042200000E+00, WithinRel( chunk.PHN(7).crossSections().back() ) );
 
   // MTRH(7) block
   CHECK( false == chunk.MTRH(7).empty() );
@@ -438,12 +441,12 @@ void verifyChunk( const PhotonuclearTable& chunk ) {
   CHECK( 90 == multiplicity.numberValues() );
 
   CHECK( 90 == multiplicity.energies().size() );
-  CHECK( 1.00000000000E+00 == Approx( multiplicity.energies().front() ) );
-  CHECK( 2.00000000000E+02 == Approx( multiplicity.energies().back() ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( multiplicity.energies().front() ) );
+  CHECK_THAT( 2.00000000000E+02, WithinRel( multiplicity.energies().back() ) );
 
   CHECK( 90 == multiplicity.multiplicities().size() );
-  CHECK( 0.00000000000E+00 == Approx( multiplicity.multiplicities().front() ) );
-  CHECK( 4.87221700000E+00 == Approx( multiplicity.multiplicities().back() ) );
+  CHECK_THAT( 5.08021000000E-19, WithinRel( multiplicity.multiplicities().front() ) );
+  CHECK_THAT( 4.87221700000E+00, WithinRel( multiplicity.multiplicities().back() ) );
 
   // ANDH(7) block
   CHECK( false == chunk.ANDH(7).empty() );

--- a/src/ACEtk/Table/Data/Parse/test/CMakeLists.txt
+++ b/src/ACEtk/Table/Data/Parse/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-
-add_executable( ACEtk.Table.Data.Parse.test Parse.test.cpp )
-target_compile_options( ACEtk.Table.Data.Parse.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Table.Data.Parse.test PUBLIC ACEtk )
-add_test( NAME ACEtk.Table.Data.Parse COMMAND ACEtk.Table.Data.Parse.test )
+add_cpp_test( Table.Data.Parse Parse.test.cpp )

--- a/src/ACEtk/Table/Data/Parse/test/Parse.test.cpp
+++ b/src/ACEtk/Table/Data/Parse/test/Parse.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Table.hpp"
 
 // other includes
@@ -217,12 +220,12 @@ SCENARIO( "Data parsing functions" ) {
       THEN( "the data is parsed correctly" ) {
 
         CHECK( 6 == result.size() );
-        CHECK( 1.00000000000E+00 == Approx(result[0] ) );
-        CHECK( 1.03125000000E+00 == Approx(result[1] ) );
-        CHECK( 1.06250000000E+00 == Approx(result[2] ) );
-        CHECK( 1.09375000000E+00 == Approx(result[3] ) );
-        CHECK( 1.12500000000E+00 == Approx(result[4] ) );
-        CHECK( 1.15625000000E+00 == Approx(result[5] ) );
+        CHECK_THAT( 1.00000000000E+00, WithinRel( result[0] ) );
+        CHECK_THAT( 1.03125000000E+00, WithinRel( result[1] ) );
+        CHECK_THAT( 1.06250000000E+00, WithinRel( result[2] ) );
+        CHECK_THAT( 1.09375000000E+00, WithinRel( result[3] ) );
+        CHECK_THAT( 1.12500000000E+00, WithinRel( result[4] ) );
+        CHECK_THAT( 1.15625000000E+00, WithinRel( result[5] ) );
       } // THEN
     } // WHEN
 

--- a/src/ACEtk/Table/Data/test/CMakeLists.txt
+++ b/src/ACEtk/Table/Data/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-
-add_executable( ACEtk.Table.Data.test Data.test.cpp )
-target_compile_options( ACEtk.Table.Data.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Table.Data.test PUBLIC ACEtk )
-add_test( NAME ACEtk.Table.Data COMMAND ACEtk.Table.Data.test )
+add_cpp_test( Table.Data Data.test.cpp )

--- a/src/ACEtk/Table/Data/test/Data.test.cpp
+++ b/src/ACEtk/Table/Data/test/Data.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Table.hpp"
 
 // other includes
@@ -226,13 +229,13 @@ void verifyChunk( const Data& chunk ) {
   CHECK( 8 == chunk.JXS( 32 ) );
 
   CHECK( 7 == chunk.XSS().size() );
-  CHECK( 1.00000000000E+00 == Approx( chunk.XSS( 1 ) ) );
-  CHECK( 1.03125000000E+00 == Approx( chunk.XSS( 2 ) ) );
-  CHECK( 1.06250000000E+00 == Approx( chunk.XSS( 3 ) ) );
-  CHECK( 1.09375000000E+00 == Approx( chunk.XSS( 4 ) ) );
-  CHECK( 1.12500000000E+00 == Approx( chunk.XSS( 5 ) ) );
-  CHECK( 1.15625000000E+00 == Approx( chunk.XSS( 6 ) ) );
-  CHECK( 1.90000000000E+00 == Approx( chunk.XSS( 7 ) ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( chunk.XSS( 1 ) ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( chunk.XSS( 2 ) ) );
+  CHECK_THAT( 1.06250000000E+00, WithinRel( chunk.XSS( 3 ) ) );
+  CHECK_THAT( 1.09375000000E+00, WithinRel( chunk.XSS( 4 ) ) );
+  CHECK_THAT( 1.12500000000E+00, WithinRel( chunk.XSS( 5 ) ) );
+  CHECK_THAT( 1.15625000000E+00, WithinRel( chunk.XSS( 6 ) ) );
+  CHECK_THAT( 1.90000000000E+00, WithinRel( chunk.XSS( 7 ) ) );
 
   CHECK( 1 == chunk.IXSS( 1 ) );
   CHECK( 1 == chunk.IXSS( 2 ) );
@@ -244,13 +247,13 @@ void verifyChunk( const Data& chunk ) {
 
   auto range = chunk.XSS( 1, 2 );
   CHECK( 2 == range.size() );
-  CHECK( 1.00000000000E+00 == Approx( range[0] ) );
-  CHECK( 1.03125000000E+00 == Approx( range[1] ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( range[0] ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( range[1] ) );
 
   range = chunk.XSS( 2, 2 );
   CHECK( 2 == range.size() );
-  CHECK( 1.03125000000E+00 == Approx( range[0] ) );
-  CHECK( 1.06250000000E+00 == Approx( range[1] ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( range[0] ) );
+  CHECK_THAT( 1.06250000000E+00, WithinRel( range[1] ) );
 
 #ifndef NDEBUG
   CHECK_THROWS( chunk.IZ( 0 ) );

--- a/src/ACEtk/Table/Header/test/CMakeLists.txt
+++ b/src/ACEtk/Table/Header/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-
-add_executable( ACEtk.Table.Header.test Header.test.cpp )
-target_compile_options( ACEtk.Table.Header.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Table.Header.test PUBLIC ACEtk )
-add_test( NAME ACEtk.Table.Header COMMAND ACEtk.Table.Header.test )
+add_cpp_test( Table.Header Header.test.cpp )

--- a/src/ACEtk/Table/Header/test/Header.test.cpp
+++ b/src/ACEtk/Table/Header/test/Header.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Table.hpp"
 
 // other includes
@@ -76,10 +79,10 @@ void verifyChunk( const Header& chunk ) {
   CHECK( "1.0.0" == chunk.VERS() );
   CHECK( "1.0.0" == chunk.version() );
   CHECK( "92238.80c" == chunk.ZAID() );
-  CHECK( 236.0058 == Approx( chunk.AWR() ) );
-  CHECK( 236.0058 == Approx( chunk.atomicWeightRatio() ) );
-  CHECK( 2.5301E-08 == Approx( chunk.TEMP() ) );
-  CHECK( 2.5301E-08 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 236.0058, WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 236.0058, WithinRel( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( chunk.TEMP() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( chunk.temperature() ) );
   CHECK( "12/13/12" == chunk.date() );
   CHECK( "U238 ENDF71x (jlconlin)  Ref. see jlconlin (ref 09/10/2012  10:00:53)"
          == chunk.title() );

--- a/src/ACEtk/Table/Header201/test/CMakeLists.txt
+++ b/src/ACEtk/Table/Header201/test/CMakeLists.txt
@@ -1,14 +1,1 @@
-
-add_executable( ACEtk.Table.Header201.test Header201.test.cpp )
-target_compile_options( ACEtk.Table.Header201.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Table.Header201.test PUBLIC ACEtk )
-add_test( NAME ACEtk.Table.Header201 COMMAND ACEtk.Table.Header201.test )
+add_cpp_test( Table.Header201 Header201.test.cpp )

--- a/src/ACEtk/Table/Header201/test/Header201.test.cpp
+++ b/src/ACEtk/Table/Header201/test/Header201.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Table.hpp"
 
 // other includes
@@ -83,10 +86,10 @@ void verifyChunk( const Header201& chunk ) {
   CHECK( "2.0.1" == chunk.VERS() );
   CHECK( "2.0.1" == chunk.version() );
   CHECK( "92238.800nc" == chunk.ZAID() );
-  CHECK( 236.0058 == Approx( chunk.AWR() ) );
-  CHECK( 236.0058 == Approx( chunk.atomicWeightRatio() ) );
-  CHECK( 2.5301E-08 == Approx( chunk.TEMP() ) );
-  CHECK( 2.5301E-08 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 236.0058, WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 236.0058, WithinRel( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( chunk.TEMP() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( chunk.temperature() ) );
   CHECK( "2018-05-01" == chunk.date() );
   CHECK( " 92238.80c  236.005800  2.5301E-08   12/13/12" == chunk.comments()[0] );
   CHECK( "U238 ENDF71x (jlconlin)  Ref. see jlconlin (ref 09/10/2012  10:00:53)    mat9237"

--- a/src/ACEtk/Table/test/CMakeLists.txt
+++ b/src/ACEtk/Table/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.Table.test Table.test.cpp )
-target_compile_options( ACEtk.Table.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Table.test PUBLIC ACEtk ) 
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.Table COMMAND ACEtk.Table.test )
+add_cpp_test( Table Table.test.cpp )

--- a/src/ACEtk/Table/test/Table.test.cpp
+++ b/src/ACEtk/Table/test/Table.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Table.hpp"
 
 // other includes
@@ -264,22 +267,22 @@ void verifyChunk( const Table& chunk ) {
   CHECK( 8 == chunk.data().JXS( 32 ) );
 
   CHECK( 6 == chunk.data().XSS().size() );
-  CHECK( 1.00000000000E+00 == Approx( chunk.data().XSS( 1 ) ) );
-  CHECK( 1.03125000000E+00 == Approx( chunk.data().XSS( 2 ) ) );
-  CHECK( 1.06250000000E+00 == Approx( chunk.data().XSS( 3 ) ) );
-  CHECK( 1.09375000000E+00 == Approx( chunk.data().XSS( 4 ) ) );
-  CHECK( 1.12500000000E+00 == Approx( chunk.data().XSS( 5 ) ) );
-  CHECK( 1.15625000000E+00 == Approx( chunk.data().XSS( 6 ) ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( chunk.data().XSS( 1 ) ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( chunk.data().XSS( 2 ) ) );
+  CHECK_THAT( 1.06250000000E+00, WithinRel( chunk.data().XSS( 3 ) ) );
+  CHECK_THAT( 1.09375000000E+00, WithinRel( chunk.data().XSS( 4 ) ) );
+  CHECK_THAT( 1.12500000000E+00, WithinRel( chunk.data().XSS( 5 ) ) );
+  CHECK_THAT( 1.15625000000E+00, WithinRel( chunk.data().XSS( 6 ) ) );
 
   auto range = chunk.data().XSS( 1, 2 );
   CHECK( 2 == range.size() );
-  CHECK( 1.00000000000E+00 == Approx( range[0] ) );
-  CHECK( 1.03125000000E+00 == Approx( range[1] ) );
+  CHECK_THAT( 1.00000000000E+00, WithinRel( range[0] ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( range[1] ) );
 
   range = chunk.data().XSS( 2, 2 );
   CHECK( 2 == range.size() );
-  CHECK( 1.03125000000E+00 == Approx( range[0] ) );
-  CHECK( 1.06250000000E+00 == Approx( range[1] ) );
+  CHECK_THAT( 1.03125000000E+00, WithinRel( range[0] ) );
+  CHECK_THAT( 1.06250000000E+00, WithinRel( range[1] ) );
 
 #ifndef NDEBUG
   CHECK_THROWS( chunk.data().IZ( 0 ) );
@@ -303,10 +306,10 @@ void verifyHeader( const Table& chunk ) {
 
   auto header = std::get< Header >( chunk.header() );
   CHECK( "92238.80c" == header.ZAID() );
-  CHECK( 236.0058 == Approx( header.AWR() ) );
-  CHECK( 236.0058 == Approx( header.atomicWeightRatio() ) );
-  CHECK( 2.5301E-08 == Approx( header.TEMP() ) );
-  CHECK( 2.5301E-08 == Approx( header.temperature() ) );
+  CHECK_THAT( 236.0058, WithinRel( header.AWR() ) );
+  CHECK_THAT( 236.0058, WithinRel( header.atomicWeightRatio() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( header.TEMP() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( header.temperature() ) );
   CHECK( "12/13/12" == header.date() );
   CHECK( "U238 ENDF71x (jlconlin)  Ref. see jlconlin (ref 09/10/2012  10:00:53)"
          == header.title() );
@@ -319,10 +322,10 @@ void verifyHeader201( const Table& chunk ) {
   CHECK( "2.0.1" == header.VERS() );
   CHECK( "2.0.1" == header.version() );
   CHECK( "92238.800nc" == header.ZAID() );
-  CHECK( 236.0058 == Approx( header.AWR() ) );
-  CHECK( 236.0058 == Approx( header.atomicWeightRatio() ) );
-  CHECK( 2.5301E-08 == Approx( header.TEMP() ) );
-  CHECK( 2.5301E-08 == Approx( header.temperature() ) );
+  CHECK_THAT( 236.0058, WithinRel( header.AWR() ) );
+  CHECK_THAT( 236.0058, WithinRel( header.atomicWeightRatio() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( header.TEMP() ) );
+  CHECK_THAT( 2.5301E-08, WithinRel( header.temperature() ) );
   CHECK( "2018-05-01" == header.date() );
   CHECK( " 92238.80c  236.005800  2.5301E-08   12/13/12" == header.comments()[0] );
   CHECK( "U238 ENDF71x (jlconlin)  Ref. see jlconlin (ref 09/10/2012  10:00:53)    mat9237"

--- a/src/ACEtk/ThermalScatteringTable/test/CMakeLists.txt
+++ b/src/ACEtk/ThermalScatteringTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.ThermalScatteringTable.test ThermalScatteringTable.test.cpp )
-target_compile_options( ACEtk.ThermalScatteringTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.ThermalScatteringTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.ThermalScatteringTable COMMAND ACEtk.ThermalScatteringTable.test )
+add_cpp_test( ThermalScatteringTable ThermalScatteringTable.test.cpp )

--- a/src/ACEtk/ThermalScatteringTable/test/ThermalScatteringTable.test.cpp
+++ b/src/ACEtk/ThermalScatteringTable/test/ThermalScatteringTable.test.cpp
@@ -1,10 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/fromFile.hpp"
+// what we are testing
 #include "ACEtk/ThermalScatteringTable.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +44,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -51,7 +54,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -61,7 +64,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -71,7 +74,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -81,7 +84,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -107,7 +110,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -117,7 +120,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -127,7 +130,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -137,7 +140,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -147,7 +150,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -178,7 +181,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -188,7 +191,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -198,7 +201,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -208,7 +211,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -218,7 +221,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -245,7 +248,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -255,7 +258,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -265,7 +268,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -275,7 +278,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -285,7 +288,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -316,7 +319,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -326,7 +329,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -336,7 +339,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -346,7 +349,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -356,7 +359,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -382,7 +385,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -392,7 +395,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -402,7 +405,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -412,7 +415,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -422,7 +425,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -453,7 +456,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -463,7 +466,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -473,7 +476,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -483,7 +486,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -493,7 +496,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -519,7 +522,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( iz.size() == iz_chunk.size() );
         for ( unsigned int i = 0; i < iz_chunk.size(); ++i ) {
 
-          CHECK( iz[i] == Approx( iz_chunk[i] ) );
+          CHECK( iz[i] == iz_chunk[i] );
         }
       } // THEN
 
@@ -529,7 +532,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( aw.size() == aw_chunk.size() );
         for ( unsigned int i = 0; i < aw_chunk.size(); ++i ) {
 
-          CHECK( aw[i] == Approx( aw_chunk[i] ) );
+          CHECK_THAT( aw[i], WithinRel( aw_chunk[i] ) );
         }
       } // THEN
 
@@ -539,7 +542,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( nxs.size() == nxs_chunk.size() );
         for ( unsigned int i = 0; i < nxs_chunk.size(); ++i ) {
 
-          CHECK( nxs[i] == Approx( nxs_chunk[i] ) );
+          CHECK( nxs[i] == nxs_chunk[i] );
         }
       } // THEN
 
@@ -549,7 +552,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( jxs.size() == jxs_chunk.size() );
         for ( unsigned int i = 0; i < jxs_chunk.size(); ++i ) {
 
-          CHECK( jxs[i] == Approx( jxs_chunk[i] ) );
+          CHECK( jxs[i] == jxs_chunk[i] );
         }
       } // THEN
 
@@ -559,7 +562,7 @@ SCENARIO( "ThermalScatteringTable" ){
         CHECK( xss.size() == xss_chunk.size() );
         for ( unsigned int i = 0; i < xss_chunk.size(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -569,7 +572,7 @@ SCENARIO( "ThermalScatteringTable" ){
 void verifyChunkH2O( const ThermalScatteringTable& chunk ) {
 
   CHECK( "h-h2o.40t" == chunk.ZAID() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.53e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 1643616 == chunk.length() );
   CHECK( 3 == chunk.IDPNI() );
@@ -594,12 +597,12 @@ void verifyChunkH2O( const ThermalScatteringTable& chunk ) {
   CHECK( 118 == chunk.ITIE().numberIncidentEnergies() );
 
   CHECK( 118 == chunk.ITIE().energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITIE().energies().front() ) );
-  CHECK( 1e-5 == Approx( chunk.ITIE().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITIE().energies().front() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.ITIE().energies().back() ) );
 
   CHECK( 118 == chunk.ITIE().crossSections().size() );
-  CHECK( 500.5451 == Approx( chunk.ITIE().crossSections().front() ) );
-  CHECK( 20.53782 == Approx( chunk.ITIE().crossSections().back() ) );
+  CHECK_THAT( 500.5451, WithinRel( chunk.ITIE().crossSections().front() ) );
+  CHECK_THAT( 20.53782, WithinRel( chunk.ITIE().crossSections().back() ) );
 
   // ITXE block
   CHECK( false == chunk.ITXE().empty() );
@@ -629,7 +632,7 @@ void verifyChunkH2O( const ThermalScatteringTable& chunk ) {
 void verifyChunkZrZrH( const ThermalScatteringTable& chunk ) {
 
   CHECK( "zr-zrh.40t" == chunk.ZAID() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.5507e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 1091556 == chunk.length() );
   CHECK( 3 == chunk.IDPNI() );
@@ -654,12 +657,12 @@ void verifyChunkZrZrH( const ThermalScatteringTable& chunk ) {
   CHECK( 91 == chunk.ITIE().numberIncidentEnergies() );
 
   CHECK( 91 == chunk.ITIE().energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITIE().energies().front() ) );
-  CHECK( 9.5e-7 == Approx( chunk.ITIE().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITIE().energies().front() ) );
+  CHECK_THAT( 9.5e-7, WithinRel( chunk.ITIE().energies().back() ) );
 
   CHECK( 91 == chunk.ITIE().crossSections().size() );
-  CHECK( 2.619597 == Approx( chunk.ITIE().crossSections().front() ) );
-  CHECK( 5.3698962 == Approx( chunk.ITIE().crossSections().back() ) );
+  CHECK_THAT( 2.619597, WithinRel( chunk.ITIE().crossSections().front() ) );
+  CHECK_THAT( 5.3698962, WithinRel( chunk.ITIE().crossSections().back() ) );
 
   // ITXE block
   CHECK( false == chunk.ITXE().empty() );
@@ -686,12 +689,12 @@ void verifyChunkZrZrH( const ThermalScatteringTable& chunk ) {
   CHECK( 91 == chunk.ITCEI()->numberIncidentEnergies() );
 
   CHECK( 91 == chunk.ITCEI()->energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITCEI()->energies().front() ) );
-  CHECK( 9.5e-7 == Approx( chunk.ITCEI()->energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITCEI()->energies().front() ) );
+  CHECK_THAT( 9.5e-7, WithinRel( chunk.ITCEI()->energies().back() ) );
 
   CHECK( 91 == chunk.ITCEI()->crossSections().size() );
-  CHECK( 6.337617 == Approx( chunk.ITCEI()->crossSections().front() ) );
-  CHECK( 0.82849246 == Approx( chunk.ITCEI()->crossSections().back() ) );
+  CHECK_THAT( 6.337617, WithinRel( chunk.ITCEI()->crossSections().front() ) );
+  CHECK_THAT( 0.82849246, WithinRel( chunk.ITCEI()->crossSections().back() ) );
 
   // ITCAI block
   CHECK( false == chunk.ITCAI()->empty() );
@@ -702,14 +705,14 @@ void verifyChunkZrZrH( const ThermalScatteringTable& chunk ) {
   CHECK( 20 == chunk.ITCAI()->NC() );
   CHECK( 20 == chunk.ITCAI()->numberDiscreteCosines() );
 
-  CHECK( -.9499973 == Approx( chunk.ITCAI()->cosines( 1 )[0] ) );
-  CHECK( .99335678 == Approx( chunk.ITCAI()->cosines( 91 )[19] ) );
+  CHECK_THAT( -.9499973, WithinRel( chunk.ITCAI()->cosines( 1 )[0] ) );
+  CHECK_THAT( .99335678, WithinRel( chunk.ITCAI()->cosines( 91 )[19] ) );
 }
 
 void verifyChunkAl( const ThermalScatteringTable& chunk ) {
 
   CHECK( "al-27.40t" == chunk.ZAID() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 2.53e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 1066414 == chunk.length() );
   CHECK( 3 == chunk.IDPNI() );
@@ -734,12 +737,12 @@ void verifyChunkAl( const ThermalScatteringTable& chunk ) {
   CHECK( 100 == chunk.ITIE().numberIncidentEnergies() );
 
   CHECK( 100 == chunk.ITIE().energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITIE().energies().front() ) );
-  CHECK( 2.18e-6 == Approx( chunk.ITIE().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITIE().energies().front() ) );
+  CHECK_THAT( 2.18e-6, WithinRel( chunk.ITIE().energies().back() ) );
 
   CHECK( 100 == chunk.ITIE().crossSections().size() );
-  CHECK( 1.677347 == Approx( chunk.ITIE().crossSections().front() ) );
-  CHECK( 1.31533352198 == Approx( chunk.ITIE().crossSections().back() ) );
+  CHECK_THAT( 1.677347, WithinRel( chunk.ITIE().crossSections().front() ) );
+  CHECK_THAT( 1.31533352198, WithinRel( chunk.ITIE().crossSections().back() ) );
 
   // ITXE block
   CHECK( false == chunk.ITXE().empty() );
@@ -760,12 +763,12 @@ void verifyChunkAl( const ThermalScatteringTable& chunk ) {
   CHECK( 119 == chunk.ITCE()->numberIncidentEnergies() );
 
   CHECK( 119 == chunk.ITCE()->energies().size() );
-  CHECK( 3.759019e-9 == Approx( chunk.ITCE()->energies().front() ) );
-  CHECK( 5.813947e-7 == Approx( chunk.ITCE()->energies().back() ) );
+  CHECK_THAT( 3.759019e-9, WithinRel( chunk.ITCE()->energies().front() ) );
+  CHECK_THAT( 5.813947e-7, WithinRel( chunk.ITCE()->energies().back() ) );
 
   CHECK( 119 == chunk.ITCE()->crossSections().size() );
-  CHECK( 5.10384187842E-09 == Approx( chunk.ITCE()->crossSections().front() ) );
-  CHECK( 7.15617224626E-08 == Approx( chunk.ITCE()->crossSections().back() ) );
+  CHECK_THAT( 5.10384187842E-09, WithinRel( chunk.ITCE()->crossSections().front() ) );
+  CHECK_THAT( 7.15617224626E-08, WithinRel( chunk.ITCE()->crossSections().back() ) );
 
   // ITCA block
   CHECK( false == chunk.ITCA().has_value() );
@@ -780,7 +783,7 @@ void verifyChunkAl( const ThermalScatteringTable& chunk ) {
 void verifyChunkDLiD( const ThermalScatteringTable& chunk ) {
 
   CHECK( "d-lid.10t" == chunk.ZAID() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature() ) );
+  CHECK_THAT( 3.4469e-8, WithinRel( chunk.temperature() ) );
 
   CHECK( 52095 == chunk.length() );
   CHECK( 3 == chunk.IDPNI() );
@@ -805,12 +808,12 @@ void verifyChunkDLiD( const ThermalScatteringTable& chunk ) {
   CHECK( 117 == chunk.ITIE().numberIncidentEnergies() );
 
   CHECK( 117 == chunk.ITIE().energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITIE().energies().front() ) );
-  CHECK( 9.85e-6 == Approx( chunk.ITIE().energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITIE().energies().front() ) );
+  CHECK_THAT( 9.85e-6, WithinRel( chunk.ITIE().energies().back() ) );
 
   CHECK( 117 == chunk.ITIE().crossSections().size() );
-  CHECK( 14.55274 == Approx( chunk.ITIE().crossSections().front() ) );
-  CHECK( 1.68978156625 == Approx( chunk.ITIE().crossSections().back() ) );
+  CHECK_THAT( 14.55274, WithinRel( chunk.ITIE().crossSections().front() ) );
+  CHECK_THAT( 1.68978156625, WithinRel( chunk.ITIE().crossSections().back() ) );
 
   // ITXE block
   CHECK( false == chunk.ITXE().empty() );
@@ -831,12 +834,12 @@ void verifyChunkDLiD( const ThermalScatteringTable& chunk ) {
   CHECK( 72 == chunk.ITCE()->numberIncidentEnergies() );
 
   CHECK( 72 == chunk.ITCE()->energies().size() );
-  CHECK( 3.70672e-9 == Approx( chunk.ITCE()->energies().front() ) );
-  CHECK( 3.66965e-7 == Approx( chunk.ITCE()->energies().back() ) );
+  CHECK_THAT( 3.70672e-9, WithinRel( chunk.ITCE()->energies().front() ) );
+  CHECK_THAT( 3.66965e-7, WithinRel( chunk.ITCE()->energies().back() ) );
 
   CHECK( 72 == chunk.ITCE()->crossSections().size() );
-  CHECK( 3.75735379520E-09 == Approx( chunk.ITCE()->crossSections().front() ) );
-  CHECK( 8.39439776800E-08 == Approx( chunk.ITCE()->crossSections().back() ) );
+  CHECK_THAT( 3.75735379520E-09, WithinRel( chunk.ITCE()->crossSections().front() ) );
+  CHECK_THAT( 8.39439776800E-08, WithinRel( chunk.ITCE()->crossSections().back() ) );
 
   // ITCA block
   CHECK( false == chunk.ITCA().has_value() );
@@ -848,12 +851,12 @@ void verifyChunkDLiD( const ThermalScatteringTable& chunk ) {
   CHECK( 117 == chunk.ITCEI()->numberIncidentEnergies() );
 
   CHECK( 117 == chunk.ITCEI()->energies().size() );
-  CHECK( 1e-11 == Approx( chunk.ITCEI()->energies().front() ) );
-  CHECK( 9.85e-6 == Approx( chunk.ITCEI()->energies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.ITCEI()->energies().front() ) );
+  CHECK_THAT( 9.85e-6, WithinRel( chunk.ITCEI()->energies().back() ) );
 
   CHECK( 117 == chunk.ITCEI()->crossSections().size() );
-  CHECK( 1.026886 == Approx( chunk.ITCEI()->crossSections().front() ) );
-  CHECK( 2.48815555289E-03 == Approx( chunk.ITCEI()->crossSections().back() ) );
+  CHECK_THAT( 1.026886, WithinRel( chunk.ITCEI()->crossSections().front() ) );
+  CHECK_THAT( 2.48815555289E-03, WithinRel( chunk.ITCEI()->crossSections().back() ) );
 
   // ITCAI block
   CHECK( false == chunk.ITCAI()->empty() );
@@ -863,6 +866,6 @@ void verifyChunkDLiD( const ThermalScatteringTable& chunk ) {
   CHECK( 20 == chunk.ITCAI()->NC() );
   CHECK( 20 == chunk.ITCAI()->numberDiscreteCosines() );
 
-  CHECK( -9.49989880639E-01 == Approx( chunk.ITCAI()->cosines( 1 )[0] ) );
-  CHECK( 9.99876836853E-01 == Approx( chunk.ITCAI()->cosines( 117 )[19] ) );
+  CHECK_THAT( -9.49989880639E-01, WithinRel( chunk.ITCAI()->cosines( 1 )[0] ) );
+  CHECK_THAT( 9.99876836853E-01, WithinRel( chunk.ITCAI()->cosines( 117 )[19] ) );
 }

--- a/src/ACEtk/Xsdir/test/CMakeLists.txt
+++ b/src/ACEtk/Xsdir/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.Xsdir.test Xsdir.test.cpp )
-target_compile_options( ACEtk.Xsdir.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.Xsdir.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.Xsdir COMMAND ACEtk.Xsdir.test )
+add_cpp_test( Xsdir Xsdir.test.cpp )

--- a/src/ACEtk/Xsdir/test/Xsdir.test.cpp
+++ b/src/ACEtk/Xsdir/test/Xsdir.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/Xsdir.hpp"
 
 // other includes
@@ -215,25 +218,25 @@ void verifyChunk( const Xsdir& chunk ) {
   CHECK( "/some/path/to/Data" == chunk.dataPath().value() );
 
   CHECK( 9 == chunk.atomicWeightRatios().size() );
-  CHECK(   1.00000000 == Approx( chunk.atomicWeightRatios().at( 1 ) ) );
-  CHECK(   0.99931697 == Approx( chunk.atomicWeightRatios().at( 1000 ) ) );
-  CHECK(   0.99916733 == Approx( chunk.atomicWeightRatios().at( 1001 ) ) );
-  CHECK(   1.99679968 == Approx( chunk.atomicWeightRatios().at( 1002 ) ) );
-  CHECK(   2.99013997 == Approx( chunk.atomicWeightRatios().at( 1003 ) ) );
-  CHECK(   3.99320563 == Approx( chunk.atomicWeightRatios().at( 1004 ) ) );
-  CHECK( 235.98412800 == Approx( chunk.atomicWeightRatios().at( 92000 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatios().at( 92235 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatios().at( 1092235 ) ) );
+  CHECK_THAT(   1.00000000, WithinRel( chunk.atomicWeightRatios().at( 1 ) ) );
+  CHECK_THAT(   0.99931697, WithinRel( chunk.atomicWeightRatios().at( 1000 ) ) );
+  CHECK_THAT(   0.99916733, WithinRel( chunk.atomicWeightRatios().at( 1001 ) ) );
+  CHECK_THAT(   1.99679968, WithinRel( chunk.atomicWeightRatios().at( 1002 ) ) );
+  CHECK_THAT(   2.99013997, WithinRel( chunk.atomicWeightRatios().at( 1003 ) ) );
+  CHECK_THAT(   3.99320563, WithinRel( chunk.atomicWeightRatios().at( 1004 ) ) );
+  CHECK_THAT( 235.98412800, WithinRel( chunk.atomicWeightRatios().at( 92000 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatios().at( 92235 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatios().at( 1092235 ) ) );
 
-  CHECK(   1.00000000 == Approx( chunk.atomicWeightRatio( 1 ) ) );
-  CHECK(   0.99931697 == Approx( chunk.atomicWeightRatio( 1000 ) ) );
-  CHECK(   0.99916733 == Approx( chunk.atomicWeightRatio( 1001 ) ) );
-  CHECK(   1.99679968 == Approx( chunk.atomicWeightRatio( 1002 ) ) );
-  CHECK(   2.99013997 == Approx( chunk.atomicWeightRatio( 1003 ) ) );
-  CHECK(   3.99320563 == Approx( chunk.atomicWeightRatio( 1004 ) ) );
-  CHECK( 235.98412800 == Approx( chunk.atomicWeightRatio( 92000 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatio( 92235 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatio( 1092235 ) ) );
+  CHECK_THAT(   1.00000000, WithinRel( chunk.atomicWeightRatio( 1 ) ) );
+  CHECK_THAT(   0.99931697, WithinRel( chunk.atomicWeightRatio( 1000 ) ) );
+  CHECK_THAT(   0.99916733, WithinRel( chunk.atomicWeightRatio( 1001 ) ) );
+  CHECK_THAT(   1.99679968, WithinRel( chunk.atomicWeightRatio( 1002 ) ) );
+  CHECK_THAT(   2.99013997, WithinRel( chunk.atomicWeightRatio( 1003 ) ) );
+  CHECK_THAT(   3.99320563, WithinRel( chunk.atomicWeightRatio( 1004 ) ) );
+  CHECK_THAT( 235.98412800, WithinRel( chunk.atomicWeightRatio( 92000 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatio( 92235 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatio( 1092235 ) ) );
 
   CHECK( 3 == chunk.entries().size() );
   CHECK( "92234.00c" == chunk.entries()[0].ZAID() );
@@ -271,25 +274,25 @@ void verifyChunkWithoutDatapath( const Xsdir& chunk ) {
   CHECK( std::nullopt == chunk.dataPath() );
 
   CHECK( 9 == chunk.atomicWeightRatios().size() );
-  CHECK(   1.00000000 == Approx( chunk.atomicWeightRatios().at( 1 ) ) );
-  CHECK(   0.99931697 == Approx( chunk.atomicWeightRatios().at( 1000 ) ) );
-  CHECK(   0.99916733 == Approx( chunk.atomicWeightRatios().at( 1001 ) ) );
-  CHECK(   1.99679968 == Approx( chunk.atomicWeightRatios().at( 1002 ) ) );
-  CHECK(   2.99013997 == Approx( chunk.atomicWeightRatios().at( 1003 ) ) );
-  CHECK(   3.99320563 == Approx( chunk.atomicWeightRatios().at( 1004 ) ) );
-  CHECK( 235.98412800 == Approx( chunk.atomicWeightRatios().at( 92000 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatios().at( 92235 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatios().at( 1092235 ) ) );
+  CHECK_THAT(   1.00000000, WithinRel( chunk.atomicWeightRatios().at( 1 ) ) );
+  CHECK_THAT(   0.99931697, WithinRel( chunk.atomicWeightRatios().at( 1000 ) ) );
+  CHECK_THAT(   0.99916733, WithinRel( chunk.atomicWeightRatios().at( 1001 ) ) );
+  CHECK_THAT(   1.99679968, WithinRel( chunk.atomicWeightRatios().at( 1002 ) ) );
+  CHECK_THAT(   2.99013997, WithinRel( chunk.atomicWeightRatios().at( 1003 ) ) );
+  CHECK_THAT(   3.99320563, WithinRel( chunk.atomicWeightRatios().at( 1004 ) ) );
+  CHECK_THAT( 235.98412800, WithinRel( chunk.atomicWeightRatios().at( 92000 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatios().at( 92235 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatios().at( 1092235 ) ) );
 
-  CHECK(   1.00000000 == Approx( chunk.atomicWeightRatio( 1 ) ) );
-  CHECK(   0.99931697 == Approx( chunk.atomicWeightRatio( 1000 ) ) );
-  CHECK(   0.99916733 == Approx( chunk.atomicWeightRatio( 1001 ) ) );
-  CHECK(   1.99679968 == Approx( chunk.atomicWeightRatio( 1002 ) ) );
-  CHECK(   2.99013997 == Approx( chunk.atomicWeightRatio( 1003 ) ) );
-  CHECK(   3.99320563 == Approx( chunk.atomicWeightRatio( 1004 ) ) );
-  CHECK( 235.98412800 == Approx( chunk.atomicWeightRatio( 92000 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatio( 92235 ) ) );
-  CHECK( 233.02478975 == Approx( chunk.atomicWeightRatio( 1092235 ) ) );
+  CHECK_THAT(   1.00000000, WithinRel( chunk.atomicWeightRatio( 1 ) ) );
+  CHECK_THAT(   0.99931697, WithinRel( chunk.atomicWeightRatio( 1000 ) ) );
+  CHECK_THAT(   0.99916733, WithinRel( chunk.atomicWeightRatio( 1001 ) ) );
+  CHECK_THAT(   1.99679968, WithinRel( chunk.atomicWeightRatio( 1002 ) ) );
+  CHECK_THAT(   2.99013997, WithinRel( chunk.atomicWeightRatio( 1003 ) ) );
+  CHECK_THAT(   3.99320563, WithinRel( chunk.atomicWeightRatio( 1004 ) ) );
+  CHECK_THAT( 235.98412800, WithinRel( chunk.atomicWeightRatio( 92000 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatio( 92235 ) ) );
+  CHECK_THAT( 233.02478975, WithinRel( chunk.atomicWeightRatio( 1092235 ) ) );
 
   CHECK( 3 == chunk.entries().size() );
   CHECK( "92234.00c" == chunk.entries()[0].ZAID() );

--- a/src/ACEtk/XsdirEntry/test/CMakeLists.txt
+++ b/src/ACEtk/XsdirEntry/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.XsdirEntry.test XsdirEntry.test.cpp )
-target_compile_options( ACEtk.XsdirEntry.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.XsdirEntry.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.XsdirEntry COMMAND ACEtk.XsdirEntry.test )
+add_cpp_test( XsdirEntry XsdirEntry.test.cpp )

--- a/src/ACEtk/XsdirEntry/test/XsdirEntry.test.cpp
+++ b/src/ACEtk/XsdirEntry/test/XsdirEntry.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/XsdirEntry.hpp"
 
 // other includes
@@ -247,8 +250,8 @@ std::string chunk() {
 void verifyChunk( const XsdirEntry& chunk ) {
 
   CHECK( "92235.00c" == chunk.ZAID() );
-  CHECK( 235. == Approx( chunk.AWR() ) );
-  CHECK( 235. == Approx( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 235., WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 235., WithinRel( chunk.atomicWeightRatio() ) );
   CHECK( "file" == chunk.fileName() );
   CHECK( std::nullopt == chunk.accessRoute() );
   CHECK( 1 == chunk.fileType() );
@@ -257,7 +260,7 @@ void verifyChunk( const XsdirEntry& chunk ) {
   CHECK( std::nullopt == chunk.recordLength() );
   CHECK( std::nullopt == chunk.entriesPerRecord() );
   CHECK( std::nullopt != chunk.temperature() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature().value() ) );
+  CHECK_THAT( 2.53e-8, WithinRel( chunk.temperature().value() ) );
   CHECK( true == chunk.ptable() );
 }
 
@@ -272,8 +275,8 @@ std::string chunkWithSplit() {
 void verifyChunkWithSplit( const XsdirEntry& chunk ) {
 
   CHECK( "92235.00c" == chunk.ZAID() );
-  CHECK( 235. == Approx( chunk.AWR() ) );
-  CHECK( 235. == Approx( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 235., WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 235., WithinRel( chunk.atomicWeightRatio() ) );
   CHECK( "filenamethatiswaaaaaaaaaaaaaaaaaaaaaaaaaytoolong" == chunk.fileName() );
   CHECK( "accessnamethatisevenwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaylonger"
          == chunk.accessRoute().value() );
@@ -283,7 +286,7 @@ void verifyChunkWithSplit( const XsdirEntry& chunk ) {
   CHECK( std::nullopt == chunk.recordLength() );
   CHECK( std::nullopt == chunk.entriesPerRecord() );
   CHECK( std::nullopt != chunk.temperature() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature().value() ) );
+  CHECK_THAT( 2.53e-8, WithinRel( chunk.temperature().value() ) );
   CHECK( true == chunk.ptable() );
 }
 
@@ -296,8 +299,8 @@ std::string chunkWith7entries() {
 void verifyChunkWith7entries( const XsdirEntry& chunk ) {
 
   CHECK( "92235.00c" == chunk.ZAID() );
-  CHECK( 235. == Approx( chunk.AWR() ) );
-  CHECK( 235. == Approx( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 235., WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 235., WithinRel( chunk.atomicWeightRatio() ) );
   CHECK( "file" == chunk.fileName() );
   CHECK( std::nullopt == chunk.accessRoute() );
   CHECK( 1 == chunk.fileType() );
@@ -318,8 +321,8 @@ std::string chunkWith10entries() {
 void verifyChunkWith10entries( const XsdirEntry& chunk ) {
 
   CHECK( "92235.00c" == chunk.ZAID() );
-  CHECK( 235. == Approx( chunk.AWR() ) );
-  CHECK( 235. == Approx( chunk.atomicWeightRatio() ) );
+  CHECK_THAT( 235., WithinRel( chunk.AWR() ) );
+  CHECK_THAT( 235., WithinRel( chunk.atomicWeightRatio() ) );
   CHECK( "file" == chunk.fileName() );
   CHECK( std::nullopt == chunk.accessRoute() );
   CHECK( 1 == chunk.fileType() );
@@ -328,6 +331,6 @@ void verifyChunkWith10entries( const XsdirEntry& chunk ) {
   CHECK( std::nullopt == chunk.recordLength() );
   CHECK( std::nullopt == chunk.entriesPerRecord() );
   CHECK( std::nullopt != chunk.temperature() );
-  CHECK( 2.53e-8 == Approx( chunk.temperature().value() ) );
+  CHECK_THAT( 2.53e-8, WithinRel( chunk.temperature().value() ) );
   CHECK( false == chunk.ptable() );
 }

--- a/src/ACEtk/continuous/AngleEnergyDistributionData/test/AngleEnergyDistributionData.test.cpp
+++ b/src/ACEtk/continuous/AngleEnergyDistributionData/test/AngleEnergyDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/AngleEnergyDistributionData.hpp"
 
 // other includes
@@ -52,7 +55,7 @@ SCENARIO( "AngleEnergyDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -72,7 +75,7 @@ SCENARIO( "AngleEnergyDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -127,11 +130,11 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
   CHECK( 2 == chunk.distributions().size() );
 
   CHECK( 2 == chunk.incidentEnergies().size() );
-  CHECK( 1e-5 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[1] ) );
 
-  CHECK( 1e-5 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(2) ) );
 
   CHECK( 27 == chunk.LOCC(1) );
   CHECK( 52 == chunk.LOCC(2) );
@@ -143,7 +146,7 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
 
   auto data1 = chunk.distribution(1);
 
-  CHECK( 1e-5 == Approx( data1.incidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( data1.incidentEnergy() ) );
 
   CHECK( 2 == data1.interpolation() );
 
@@ -151,11 +154,11 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
   CHECK( 2 == data1.numberCosines() );
 
   CHECK( 2 == data1.cosines().size() );
-  CHECK( -1. == Approx( data1.cosines()[0] ) );
-  CHECK( 1. == Approx( data1.cosines()[1] ) );
+  CHECK_THAT( -1., WithinRel( data1.cosines()[0] ) );
+  CHECK_THAT( 1., WithinRel( data1.cosines()[1] ) );
 
-  CHECK( -1 == Approx( data1.cosine(1) ) );
-  CHECK( 1. == Approx( data1.cosine(2) ) );
+  CHECK_THAT( -1, WithinRel( data1.cosine(1) ) );
+  CHECK_THAT( 1., WithinRel( data1.cosine(2) ) );
 
   CHECK( 33 == data1.LOCC(1) );
   CHECK( 44 == data1.LOCC(2) );
@@ -166,42 +169,42 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
   CHECK( 18 == data1.relativeDistributionLocator(2) );
 
   auto data11 = data1.distribution(1);
-  CHECK( -1. == Approx( data11.energyOrCosine() ) );
+  CHECK_THAT( -1., WithinRel( data11.energyOrCosine() ) );
   CHECK( 2 == data11.interpolation() );
   CHECK( 3 == data11.numberOutgoingEnergies() );
 
   CHECK( 3 == data11.outgoingEnergies().size() );
-  CHECK( 1e-5 == Approx( data11.outgoingEnergies().front() ) );
-  CHECK( 20. == Approx( data11.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-5, WithinRel( data11.outgoingEnergies().front() ) );
+  CHECK_THAT( 20., WithinRel( data11.outgoingEnergies().back() ) );
 
   CHECK( 3 == data11.pdf().size() );
-  CHECK( .5 == Approx( data11.pdf().front() ) );
-  CHECK( .5 == Approx( data11.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data11.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data11.pdf().back() ) );
 
   CHECK( 3 == data11.cdf().size() );
-  CHECK( 0. == Approx( data11.cdf().front() ) );
-  CHECK( 1. == Approx( data11.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data11.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data11.cdf().back() ) );
 
   auto data12 = data1.distribution(2);
-  CHECK( 1. == Approx( data12.energyOrCosine() ) );
+  CHECK_THAT( 1., WithinRel( data12.energyOrCosine() ) );
   CHECK( 1 == data12.interpolation() );
   CHECK( 2 == data12.numberOutgoingEnergies() );
 
   CHECK( 2 == data12.outgoingEnergies().size() );
-  CHECK( 1e-3 == Approx( data12.outgoingEnergies().front() ) );
-  CHECK( 15. == Approx( data12.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-3, WithinRel( data12.outgoingEnergies().front() ) );
+  CHECK_THAT( 15., WithinRel( data12.outgoingEnergies().back() ) );
 
   CHECK( 2 == data12.pdf().size() );
-  CHECK( .5 == Approx( data12.pdf().front() ) );
-  CHECK( .5 == Approx( data12.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data12.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data12.pdf().back() ) );
 
   CHECK( 2 == data12.cdf().size() );
-  CHECK( 0. == Approx( data12.cdf().front() ) );
-  CHECK( 1. == Approx( data12.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data12.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data12.cdf().back() ) );
 
   auto data2 = chunk.distribution(2);
 
-  CHECK( 20. == Approx( data2.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy() ) );
 
   CHECK( 2 == data2.interpolation() );
 
@@ -209,11 +212,11 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
   CHECK( 2 == data2.numberCosines() );
 
   CHECK( 2 == data2.cosines().size() );
-  CHECK( -0.9 == Approx( data2.cosines()[0] ) );
-  CHECK( 0.9 == Approx( data2.cosines()[1] ) );
+  CHECK_THAT( -0.9, WithinRel( data2.cosines()[0] ) );
+  CHECK_THAT( 0.9, WithinRel( data2.cosines()[1] ) );
 
-  CHECK( -0.9 == Approx( data2.cosine(1) ) );
-  CHECK( 0.9 == Approx( data2.cosine(2) ) );
+  CHECK_THAT( -0.9, WithinRel( data2.cosine(1) ) );
+  CHECK_THAT( 0.9, WithinRel( data2.cosine(2) ) );
 
   CHECK( 58 == data2.LOCC(1) );
   CHECK( 66 == data2.LOCC(2) );
@@ -224,36 +227,36 @@ void verifyChunk( const AngleEnergyDistributionData& chunk ) {
   CHECK( 15 == data2.relativeDistributionLocator(2) );
 
   auto data21 = data2.distribution(1);
-  CHECK( -0.9 == Approx( data21.energyOrCosine() ) );
+  CHECK_THAT( -0.9, WithinRel( data21.energyOrCosine() ) );
   CHECK( 1 == data21.interpolation() );
   CHECK( 2 == data21.numberOutgoingEnergies() );
 
   CHECK( 2 == data21.outgoingEnergies().size() );
-  CHECK( 1e-4 == Approx( data21.outgoingEnergies().front() ) );
-  CHECK( 12. == Approx( data21.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-4, WithinRel( data21.outgoingEnergies().front() ) );
+  CHECK_THAT( 12., WithinRel( data21.outgoingEnergies().back() ) );
 
   CHECK( 2 == data21.pdf().size() );
-  CHECK( .5 == Approx( data21.pdf().front() ) );
-  CHECK( .5 == Approx( data21.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data21.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data21.pdf().back() ) );
 
   CHECK( 2 == data21.cdf().size() );
-  CHECK( 0. == Approx( data21.cdf().front() ) );
-  CHECK( 1. == Approx( data21.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data21.cdf().back() ) );
 
   auto data22 = data2.distribution(2);
-  CHECK( 0.9 == Approx( data22.energyOrCosine() ) );
+  CHECK_THAT( 0.9, WithinRel( data22.energyOrCosine() ) );
   CHECK( 2 == data22.interpolation() );
   CHECK( 3 == data22.numberOutgoingEnergies() );
 
   CHECK( 3 == data22.outgoingEnergies().size() );
-  CHECK( 1e-2 == Approx( data22.outgoingEnergies().front() ) );
-  CHECK( 18. == Approx( data22.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-2, WithinRel( data22.outgoingEnergies().front() ) );
+  CHECK_THAT( 18., WithinRel( data22.outgoingEnergies().back() ) );
 
   CHECK( 3 == data22.pdf().size() );
-  CHECK( .5 == Approx( data22.pdf().front() ) );
-  CHECK( .5 == Approx( data22.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data22.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data22.pdf().back() ) );
 
   CHECK( 3 == data22.cdf().size() );
-  CHECK( 0. == Approx( data22.cdf().front() ) );
-  CHECK( 1. == Approx( data22.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data22.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data22.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/AngleEnergyDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/AngleEnergyDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.AngleEnergyDistributionData.test AngleEnergyDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.AngleEnergyDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.AngleEnergyDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.AngleEnergyDistributionData COMMAND ACEtk.continuous.AngleEnergyDistributionData.test )
+add_cpp_test( continuous.AngleEnergyDistributionData AngleEnergyDistributionData.test.cpp )

--- a/src/ACEtk/continuous/AngularDistributionBlock/test/AngularDistributionBlock.test.cpp
+++ b/src/ACEtk/continuous/AngularDistributionBlock/test/AngularDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/AngularDistributionBlock.hpp"
 
 // other includes
@@ -58,7 +61,7 @@ SCENARIO( "AngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -77,7 +80,7 @@ SCENARIO( "AngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -148,10 +151,10 @@ void verifyChunk( const AngularDistributionBlock& chunk ) {
   CHECK( 2 == data1.NE() );
   CHECK( 2 == data1.numberIncidentEnergies() );
   CHECK( 2 == data1.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( data1.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( data1.incidentEnergies()[1] ) );
-  CHECK( 1e-11 == Approx( data1.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( data1.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-11, WithinRel( data1.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( data1.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-11, WithinRel( data1.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( data1.incidentEnergy(2) ) );
   CHECK( -6 == data1.LOCC(1) );
   CHECK( -14 == data1.LOCC(2) );
   CHECK( -6 == data1.distributionLocator(1) );
@@ -167,12 +170,12 @@ void verifyChunk( const AngularDistributionBlock& chunk ) {
   CHECK( 3 == data4.NE() );
   CHECK( 3 == data4.numberIncidentEnergies() );
   CHECK( 3 == data4.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( data4.incidentEnergies()[0] ) );
-  CHECK( 1. == Approx( data4.incidentEnergies()[1] ) );
-  CHECK( 20. == Approx( data4.incidentEnergies()[2] ) );
-  CHECK( 1e-11 == Approx( data4.incidentEnergy(1) ) );
-  CHECK( 1. == Approx( data4.incidentEnergy(2) ) );
-  CHECK( 20. == Approx( data4.incidentEnergy(3) ) );
+  CHECK_THAT( 1e-11, WithinRel( data4.incidentEnergies()[0] ) );
+  CHECK_THAT( 1., WithinRel( data4.incidentEnergies()[1] ) );
+  CHECK_THAT( 20., WithinRel( data4.incidentEnergies()[2] ) );
+  CHECK_THAT( 1e-11, WithinRel( data4.incidentEnergy(1) ) );
+  CHECK_THAT( 1., WithinRel( data4.incidentEnergy(2) ) );
+  CHECK_THAT( 20., WithinRel( data4.incidentEnergy(3) ) );
   CHECK( -32 == data4.LOCC(1) );
   CHECK( 0 == data4.LOCC(2) );
   CHECK( -43 == data4.LOCC(3) );

--- a/src/ACEtk/continuous/AngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/AngularDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.AngularDistributionBlock.test AngularDistributionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.AngularDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.AngularDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.AngularDistributionBlock COMMAND ACEtk.continuous.AngularDistributionBlock.test )
+add_cpp_test( continuous.AngularDistributionBlock AngularDistributionBlock.test.cpp )

--- a/src/ACEtk/continuous/AngularDistributionData/test/AngularDistributionData.test.cpp
+++ b/src/ACEtk/continuous/AngularDistributionData/test/AngularDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/AngularDistributionData.hpp"
 
 // other includes
@@ -51,7 +54,7 @@ SCENARIO( "AngularDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -71,7 +74,7 @@ SCENARIO( "AngularDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -112,13 +115,13 @@ void verifyChunk( const AngularDistributionData& chunk ) {
   CHECK( 3 == chunk.distributions().size() );
 
   CHECK( 3 == chunk.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 1. == Approx( chunk.incidentEnergies()[1] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[2] ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[2] ) );
 
-  CHECK( 1e-11 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 1. == Approx( chunk.incidentEnergy(2) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(3) ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 1., WithinRel( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(3) ) );
 
   CHECK( 0 == chunk.LOCC(1) );
   CHECK( 13 == chunk.LOCC(2) );

--- a/src/ACEtk/continuous/AngularDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/AngularDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.AngularDistributionData.test AngularDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.AngularDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.AngularDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.AngularDistributionData COMMAND ACEtk.continuous.AngularDistributionData.test )
+add_cpp_test( continuous.AngularDistributionData AngularDistributionData.test.cpp )

--- a/src/ACEtk/continuous/CrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/CrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.CrossSectionBlock.test CrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.CrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.CrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.CrossSectionBlock COMMAND ACEtk.continuous.CrossSectionBlock.test )
+add_cpp_test( continuous.CrossSectionBlock CrossSectionBlock.test.cpp )

--- a/src/ACEtk/continuous/CrossSectionBlock/test/CrossSectionBlock.test.cpp
+++ b/src/ACEtk/continuous/CrossSectionBlock/test/CrossSectionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/CrossSectionBlock.hpp"
 
 // other includes
@@ -116,7 +119,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -135,7 +138,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -246,60 +249,60 @@ void verifyChunk( const CrossSectionBlock& chunk ) {
   CHECK( 1 == chunk.energyIndex(1) );
   CHECK( 99 == chunk.numberValues(1) );
   CHECK( 99 == chunk.crossSections(1).size() );
-  CHECK( 17.17401 == Approx( chunk.crossSections(1).front() ) );
-  CHECK( 2.72235400000E-05 == Approx( chunk.crossSections(1).back() ) );
+  CHECK_THAT( 17.17401, WithinRel( chunk.crossSections(1).front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( chunk.crossSections(1).back() ) );
 
   CHECK( 1 == chunk.energyIndex(2) );
   CHECK( 99 == chunk.numberValues(2) );
   CHECK( 99 == chunk.crossSections(2).size() );
-  CHECK( 18.17401 == Approx( chunk.crossSections(2).front() ) );
-  CHECK( 2.72235400000E-05 == Approx( chunk.crossSections(2).back() ) );
+  CHECK_THAT( 18.17401, WithinRel( chunk.crossSections(2).front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( chunk.crossSections(2).back() ) );
 
   CHECK( 1 == chunk.energyIndex(3) );
   CHECK( 99 == chunk.numberValues(3) );
   CHECK( 99 == chunk.crossSections(3).size() );
-  CHECK( 9.02129200000E-03 == Approx( chunk.crossSections(3).front() ) );
-  CHECK( 3.06769500000E-04 == Approx( chunk.crossSections(3).back() ) );
+  CHECK_THAT( 9.02129200000E-03, WithinRel( chunk.crossSections(3).front() ) );
+  CHECK_THAT( 3.06769500000E-04, WithinRel( chunk.crossSections(3).back() ) );
 
   auto xs = chunk.crossSectionData(1);
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 17.17401 == Approx( xs.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.crossSectionData(2);
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 18.17401 == Approx( xs.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 18.17401, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.crossSectionData(3);
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 9.02129200000E-03 == Approx( xs.crossSections().front() ) );
-  CHECK( 3.06769500000E-04 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 9.02129200000E-03, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 3.06769500000E-04, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.data()[0];
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 17.17401 == Approx( xs.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.data()[1];
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 18.17401 == Approx( xs.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 18.17401, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.data()[2];
   CHECK( 1 == xs.energyIndex() );
   CHECK( 99 == xs.numberValues() );
   CHECK( 99 == xs.crossSections().size() );
-  CHECK( 9.02129200000E-03 == Approx( xs.crossSections().front() ) );
-  CHECK( 3.06769500000E-04 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 9.02129200000E-03, WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 3.06769500000E-04, WithinRel( xs.crossSections().back() ) );
 }

--- a/src/ACEtk/continuous/CrossSectionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/CrossSectionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.CrossSectionData.test CrossSectionData.test.cpp )
-target_compile_options( ACEtk.continuous.CrossSectionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.CrossSectionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.CrossSectionData COMMAND ACEtk.continuous.CrossSectionData.test )
+add_cpp_test( continuous.CrossSectionData CrossSectionData.test.cpp )

--- a/src/ACEtk/continuous/CrossSectionData/test/CrossSectionData.test.cpp
+++ b/src/ACEtk/continuous/CrossSectionData/test/CrossSectionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/CrossSectionData.hpp"
 
 // other includes
@@ -62,7 +65,7 @@ SCENARIO( "CrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -81,7 +84,7 @@ SCENARIO( "CrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -130,6 +133,6 @@ void verifyChunk( const CrossSectionData& chunk ) {
   CHECK( 99 == chunk.numberValues() );
 
   CHECK( 99 == chunk.crossSections().size() );
-  CHECK( 17.17401 == Approx( chunk.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( chunk.crossSections().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( chunk.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( chunk.crossSections().back() ) );
 }

--- a/src/ACEtk/continuous/DelayedNeutronPrecursorBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/DelayedNeutronPrecursorBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.DelayedNeutronPrecursorBlock.test DelayedNeutronPrecursorBlock.test.cpp )
-target_compile_options( ACEtk.continuous.DelayedNeutronPrecursorBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.DelayedNeutronPrecursorBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.DelayedNeutronPrecursorBlock COMMAND ACEtk.continuous.DelayedNeutronPrecursorBlock.test )
+add_cpp_test( continuous.DelayedNeutronPrecursorBlock DelayedNeutronPrecursorBlock.test.cpp )

--- a/src/ACEtk/continuous/DelayedNeutronPrecursorBlock/test/DelayedNeutronPrecursorBlock.test.cpp
+++ b/src/ACEtk/continuous/DelayedNeutronPrecursorBlock/test/DelayedNeutronPrecursorBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/DelayedNeutronPrecursorBlock.hpp"
 
 // other includes
@@ -44,7 +47,7 @@ SCENARIO( "DelayedNeutronPrecursorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -64,7 +67,7 @@ SCENARIO( "DelayedNeutronPrecursorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -74,10 +77,10 @@ SCENARIO( "DelayedNeutronPrecursorBlock" ) {
 std::vector< double > chunk() {
 
   return {  2.30000000000E-04,                   0,                   3,
-            1.00000000000E-11,   1.00000000000E+00,   2.00000000000E+01,   1.20000000000E-03,
+            1.00000000000E-05,   1.00000000000E+00,   2.00000000000E+01,   1.20000000000E-03,
             2.50000000000E-02,   1.00000000000E+00,
             3.20000000000E-04,                   0,                   2,
-            1.00000000000E-11,   2.00000000000E+01,   2.40000000000E-03,   2.00000000000E+00 };
+            1.00000000000E-05,   2.00000000000E+01,   2.40000000000E-03,   2.00000000000E+00 };
 }
 
 void verifyChunk( const DelayedNeutronPrecursorBlock& chunk ) {
@@ -93,8 +96,8 @@ void verifyChunk( const DelayedNeutronPrecursorBlock& chunk ) {
   decltype(auto) group1 = chunk.precursorGroupData( 1 );
   CHECK( 1 == group1.number() );
 
-  CHECK( 2.3e-4 == Approx( group1.DEC() ) );
-  CHECK( 2.3e-4 == Approx( group1.decayConstant() ) );
+  CHECK_THAT( 2.3e-4, WithinRel( group1.DEC() ) );
+  CHECK_THAT( 2.3e-4, WithinRel( group1.decayConstant() ) );
 
   CHECK( 0 == group1.interpolationData().NB() );
   CHECK( 0 == group1.interpolationData().numberInterpolationRegions() );
@@ -114,20 +117,20 @@ void verifyChunk( const DelayedNeutronPrecursorBlock& chunk ) {
   CHECK( 3 == group1.numberValues() );
 
   CHECK( 3 == group1.energies().size() );
-  CHECK( 1e-11 == Approx( group1.energies()[0] ) );
-  CHECK( 1. == Approx( group1.energies()[1] ) );
-  CHECK( 20. == Approx( group1.energies()[2] ) );
+  CHECK_THAT( 1e-5, WithinRel( group1.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( group1.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( group1.energies()[2] ) );
 
   CHECK( 3 == group1.probabilities().size() );
-  CHECK( 1.2e-3 == Approx( group1.probabilities()[0] ) );
-  CHECK( 2.5e-2 == Approx( group1.probabilities()[1] ) );
-  CHECK( 1. == Approx( group1.probabilities()[2] ) );
+  CHECK_THAT( 1.2e-3, WithinRel( group1.probabilities()[0] ) );
+  CHECK_THAT( 2.5e-2, WithinRel( group1.probabilities()[1] ) );
+  CHECK_THAT( 1., WithinRel( group1.probabilities()[2] ) );
 
   decltype(auto) group2 = chunk.precursorGroupData( 2 );
   CHECK( 2 == group2.number() );
 
-  CHECK( 3.2e-4 == Approx( group2.DEC() ) );
-  CHECK( 3.2e-4 == Approx( group2.decayConstant() ) );
+  CHECK_THAT( 3.2e-4, WithinRel( group2.DEC() ) );
+  CHECK_THAT( 3.2e-4, WithinRel( group2.decayConstant() ) );
 
   CHECK( 0 == group2.interpolationData().NB() );
   CHECK( 0 == group2.interpolationData().numberInterpolationRegions() );
@@ -147,10 +150,10 @@ void verifyChunk( const DelayedNeutronPrecursorBlock& chunk ) {
   CHECK( 2 == group2.numberValues() );
 
   CHECK( 2 == group2.energies().size() );
-  CHECK( 1e-11 == Approx( group2.energies()[0] ) );
-  CHECK( 20. == Approx( group2.energies()[1] ) );
+  CHECK_THAT( 1e-5, WithinRel( group2.energies()[0] ) );
+  CHECK_THAT( 20., WithinRel( group2.energies()[1] ) );
 
   CHECK( 2 == group2.probabilities().size() );
-  CHECK( 2.4e-3 == Approx( group2.probabilities()[0] ) );
-  CHECK( 2. == Approx( group2.probabilities()[1] ) );
+  CHECK_THAT( 2.4e-3, WithinRel( group2.probabilities()[0] ) );
+  CHECK_THAT( 2., WithinRel( group2.probabilities()[1] ) );
 }

--- a/src/ACEtk/continuous/DelayedNeutronPrecursorData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/DelayedNeutronPrecursorData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.DelayedNeutronPrecursorData.test DelayedNeutronPrecursorData.test.cpp )
-target_compile_options( ACEtk.continuous.DelayedNeutronPrecursorData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.DelayedNeutronPrecursorData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.DelayedNeutronPrecursorData COMMAND ACEtk.continuous.DelayedNeutronPrecursorData.test )
+add_cpp_test( continuous.DelayedNeutronPrecursorData DelayedNeutronPrecursorData.test.cpp )

--- a/src/ACEtk/continuous/DelayedNeutronPrecursorData/test/DelayedNeutronPrecursorData.test.cpp
+++ b/src/ACEtk/continuous/DelayedNeutronPrecursorData/test/DelayedNeutronPrecursorData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/DelayedNeutronPrecursorData.hpp"
 
 // other includes
@@ -40,7 +43,7 @@ SCENARIO( "DelayedNeutronPrecursorData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +63,7 @@ SCENARIO( "DelayedNeutronPrecursorData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -70,7 +73,7 @@ SCENARIO( "DelayedNeutronPrecursorData" ) {
 std::vector< double > chunk() {
 
   return {  2.30000000000E-04,                   0,                   3,
-            1.00000000000E-11,   1.00000000000E+00,   2.00000000000E+01,   1.20000000000E-03,
+            1.00000000000E-05,   1.00000000000E+00,   2.00000000000E+01,   1.20000000000E-03,
             2.50000000000E-02,   1.00000000000E+00 };
 }
 
@@ -82,8 +85,8 @@ void verifyChunk( const DelayedNeutronPrecursorData& chunk ) {
 
   CHECK( 1 == chunk.number() );
 
-  CHECK( 2.3e-4 == Approx( chunk.DEC() ) );
-  CHECK( 2.3e-4 == Approx( chunk.decayConstant() ) );
+  CHECK_THAT( 2.3e-4, WithinRel( chunk.DEC() ) );
+  CHECK_THAT( 2.3e-4, WithinRel( chunk.decayConstant() ) );
 
   CHECK( 0 == chunk.interpolationData().NB() );
   CHECK( 0 == chunk.interpolationData().numberInterpolationRegions() );
@@ -103,12 +106,12 @@ void verifyChunk( const DelayedNeutronPrecursorData& chunk ) {
   CHECK( 3 == chunk.numberValues() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1e-11 == Approx( chunk.energies()[0] ) );
-  CHECK( 1. == Approx( chunk.energies()[1] ) );
-  CHECK( 20. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.probabilities().size() );
-  CHECK( 1.2e-3 == Approx( chunk.probabilities()[0] ) );
-  CHECK( 2.5e-2 == Approx( chunk.probabilities()[1] ) );
-  CHECK( 1. == Approx( chunk.probabilities()[2] ) );
+  CHECK_THAT( 1.2e-3, WithinRel( chunk.probabilities()[0] ) );
+  CHECK_THAT( 2.5e-2, WithinRel( chunk.probabilities()[1] ) );
+  CHECK_THAT( 1., WithinRel( chunk.probabilities()[2] ) );
 }

--- a/src/ACEtk/continuous/DiscretePhotonDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/DiscretePhotonDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.DiscretePhotonDistribution.test DiscretePhotonDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.DiscretePhotonDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.DiscretePhotonDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.DiscretePhotonDistribution COMMAND ACEtk.continuous.DiscretePhotonDistribution.test )
+add_cpp_test( continuous.DiscretePhotonDistribution DiscretePhotonDistribution.test.cpp )

--- a/src/ACEtk/continuous/DiscretePhotonDistribution/test/DiscretePhotonDistribution.test.cpp
+++ b/src/ACEtk/continuous/DiscretePhotonDistribution/test/DiscretePhotonDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/DiscretePhotonDistribution.hpp"
 
 // other includes
@@ -38,7 +41,7 @@ SCENARIO( "DiscretePhotonDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "DiscretePhotonDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -80,12 +83,12 @@ void verifyChunk( const DiscretePhotonDistribution& chunk ) {
   CHECK( EnergyDistributionType::DiscretePhoton == chunk.LAW() );
   CHECK( EnergyDistributionType::DiscretePhoton == chunk.type() );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
-  CHECK( 2 == Approx( chunk.LP() ) );
-  CHECK( 2 == Approx( chunk.primaryPhotonFlag() ) );
-  CHECK( true == Approx( chunk.isPrimaryPhoton() ) );
-  CHECK( 1e+5 == Approx( chunk.EG() ) );
-  CHECK( 1e+5 == Approx( chunk.photonOrBindingEnergy() ) );
+  CHECK( 2 == chunk.LP() );
+  CHECK( 2 == chunk.primaryPhotonFlag() );
+  CHECK( true == chunk.isPrimaryPhoton() );
+  CHECK_THAT( 1e+5, WithinRel( chunk.EG() ) );
+  CHECK_THAT( 1e+5, WithinRel( chunk.photonOrBindingEnergy() ) );
 }

--- a/src/ACEtk/continuous/DistributionProbability/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/DistributionProbability/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.DistributionProbability.test DistributionProbability.test.cpp )
-target_compile_options( ACEtk.continuous.DistributionProbability.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.DistributionProbability.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.DistributionProbability COMMAND ACEtk.continuous.DistributionProbability.test )
+add_cpp_test( continuous.DistributionProbability DistributionProbability.test.cpp )

--- a/src/ACEtk/continuous/DistributionProbability/test/DistributionProbability.test.cpp
+++ b/src/ACEtk/continuous/DistributionProbability/test/DistributionProbability.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/DistributionProbability.hpp"
 
 // other includes
@@ -41,7 +44,7 @@ SCENARIO( "DistributionProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -61,7 +64,7 @@ SCENARIO( "DistributionProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -97,12 +100,12 @@ void verifyChunk( const DistributionProbability& chunk ) {
   CHECK( 3 == chunk.numberEnergyPoints() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1. == Approx( chunk.energies()[0] ) );
-  CHECK( 3. == Approx( chunk.energies()[1] ) );
-  CHECK( 5. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 5., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.probabilities().size() );
-  CHECK( 2. == Approx( chunk.probabilities()[0] ) );
-  CHECK( 4. == Approx( chunk.probabilities()[1] ) );
-  CHECK( 6. == Approx( chunk.probabilities()[2] ) );
+  CHECK_THAT( 2., WithinRel( chunk.probabilities()[0] ) );
+  CHECK_THAT( 4., WithinRel( chunk.probabilities()[1] ) );
+  CHECK_THAT( 6., WithinRel( chunk.probabilities()[2] ) );
 }

--- a/src/ACEtk/continuous/EnergyAngleDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EnergyAngleDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EnergyAngleDistributionData.test EnergyAngleDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.EnergyAngleDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EnergyAngleDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EnergyAngleDistributionData COMMAND ACEtk.continuous.EnergyAngleDistributionData.test )
+add_cpp_test( continuous.EnergyAngleDistributionData EnergyAngleDistributionData.test.cpp )

--- a/src/ACEtk/continuous/EnergyAngleDistributionData/test/EnergyAngleDistributionData.test.cpp
+++ b/src/ACEtk/continuous/EnergyAngleDistributionData/test/EnergyAngleDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EnergyAngleDistributionData.hpp"
 
 // other includes
@@ -52,7 +55,7 @@ SCENARIO( "EnergyAngleDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -72,7 +75,7 @@ SCENARIO( "EnergyAngleDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -131,11 +134,11 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
   CHECK( 2 == chunk.numberIncidentEnergies() );
 
   CHECK( 2 == chunk.incidentEnergies().size() );
-  CHECK( 1e-5 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[1] ) );
 
-  CHECK( 1e-5 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(2) ) );
 
   CHECK( 27 == chunk.LOCC(1) );
   CHECK( 56 == chunk.LOCC(2) );
@@ -147,7 +150,7 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
 
   auto data1 = chunk.distribution(1);
 
-  CHECK( 1e-5 == Approx( data1.incidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( data1.incidentEnergy() ) );
 
   CHECK( 2 == data1.interpolation() );
 
@@ -155,25 +158,25 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
   CHECK( 2 == data1.numberOutgoingEnergies() );
 
   CHECK( 2 == data1.outgoingEnergies().size() );
-  CHECK( 2.1 == Approx( data1.outgoingEnergies()[0] ) );
-  CHECK( 20. == Approx( data1.outgoingEnergies()[1] ) );
+  CHECK_THAT( 2.1, WithinRel( data1.outgoingEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( data1.outgoingEnergies()[1] ) );
 
   CHECK( 2 == data1.pdf().size() );
-  CHECK( 0.5 == Approx( data1.pdf()[0] ) );
-  CHECK( 0.5 == Approx( data1.pdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( data1.pdf()[0] ) );
+  CHECK_THAT( 0.5, WithinRel( data1.pdf()[1] ) );
 
   CHECK( 2 == data1.cdf().size() );
-  CHECK( 0.5 == Approx( data1.cdf()[0] ) );
-  CHECK( 1.0 == Approx( data1.cdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( data1.cdf()[0] ) );
+  CHECK_THAT( 1.0, WithinRel( data1.cdf()[1] ) );
 
-  CHECK( 2.1 == Approx( data1.outgoingEnergy(1) ) );
-  CHECK( 20. == Approx( data1.outgoingEnergy(2) ) );
+  CHECK_THAT( 2.1, WithinRel( data1.outgoingEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( data1.outgoingEnergy(2) ) );
 
-  CHECK( 0.5 == Approx( data1.probability(1) ) );
-  CHECK( 0.5 == Approx( data1.probability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( data1.probability(1) ) );
+  CHECK_THAT( 0.5, WithinRel( data1.probability(2) ) );
 
-  CHECK( 0.5 == Approx( data1.cumulativeProbability(1) ) );
-  CHECK( 1.0 == Approx( data1.cumulativeProbability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( data1.cumulativeProbability(1) ) );
+  CHECK_THAT( 1.0, WithinRel( data1.cumulativeProbability(2) ) );
 
   CHECK( 37 == data1.LOCC(1) );
   CHECK( 48 == data1.LOCC(2) );
@@ -184,46 +187,46 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
   CHECK( 22 == data1.relativeDistributionLocator(2) );
 
   auto data11 = data1.distribution(1);
-  CHECK( 2.1 == Approx( data11.energy() ) );
-  CHECK( 0.5 == Approx( data11.probability() ) );
-  CHECK( 0.5 == Approx( data11.cumulativeProbability() ) );
+  CHECK_THAT( 2.1, WithinRel( data11.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data11.probability() ) );
+  CHECK_THAT( 0.5, WithinRel( data11.cumulativeProbability() ) );
   CHECK( 2 == data11.interpolation() );
   CHECK( 3 == data11.numberCosines() );
 
   CHECK( 3 == data11.cosines().size() );
-  CHECK( -1. == Approx( data11.cosines().front() ) );
-  CHECK( +1. == Approx( data11.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data11.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data11.cosines().back() ) );
 
   CHECK( 3 == data11.pdf().size() );
-  CHECK( .5 == Approx( data11.pdf().front() ) );
-  CHECK( .5 == Approx( data11.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data11.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data11.pdf().back() ) );
 
   CHECK( 3 == data11.cdf().size() );
-  CHECK( 0. == Approx( data11.cdf().front() ) );
-  CHECK( 1. == Approx( data11.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data11.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data11.cdf().back() ) );
 
   auto data12 = data1.distribution(2);
-  CHECK( 20 == Approx( data12.energy() ) );
-  CHECK( 0.5 == Approx( data12.probability() ) );
-  CHECK( 1.0 == Approx( data12.cumulativeProbability() ) );
+  CHECK_THAT( 20, WithinRel( data12.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data12.probability() ) );
+  CHECK_THAT( 1.0, WithinRel( data12.cumulativeProbability() ) );
   CHECK( 1 == data12.interpolation() );
   CHECK( 2 == data12.numberCosines() );
 
   CHECK( 2 == data12.cosines().size() );
-  CHECK( -1. == Approx( data12.cosines().front() ) );
-  CHECK( +1. == Approx( data12.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data12.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data12.cosines().back() ) );
 
   CHECK( 2 == data12.pdf().size() );
-  CHECK( .5 == Approx( data12.pdf().front() ) );
-  CHECK( .5 == Approx( data12.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data12.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data12.pdf().back() ) );
 
   CHECK( 2 == data12.cdf().size() );
-  CHECK( 0. == Approx( data12.cdf().front() ) );
-  CHECK( 1. == Approx( data12.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data12.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data12.cdf().back() ) );
 
   auto data2 = chunk.distribution(2);
 
-  CHECK( 20. == Approx( data2.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy() ) );
 
   CHECK( 2 == data2.interpolation() );
 
@@ -231,25 +234,25 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
   CHECK( 2 == data2.numberOutgoingEnergies() );
 
   CHECK( 2 == data2.outgoingEnergies().size() );
-  CHECK( 1.1 == Approx( data2.outgoingEnergies()[0] ) );
-  CHECK( 15. == Approx( data2.outgoingEnergies()[1] ) );
+  CHECK_THAT( 1.1, WithinRel( data2.outgoingEnergies()[0] ) );
+  CHECK_THAT( 15., WithinRel( data2.outgoingEnergies()[1] ) );
 
   CHECK( 2 == data2.pdf().size() );
-  CHECK( 0.5 == Approx( data2.pdf()[0] ) );
-  CHECK( 0.5 == Approx( data2.pdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( data2.pdf()[0] ) );
+  CHECK_THAT( 0.5, WithinRel( data2.pdf()[1] ) );
 
   CHECK( 2 == data1.cdf().size() );
-  CHECK( 0.5 == Approx( data2.cdf()[0] ) );
-  CHECK( 1.0 == Approx( data2.cdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( data2.cdf()[0] ) );
+  CHECK_THAT( 1.0, WithinRel( data2.cdf()[1] ) );
 
-  CHECK( 1.1 == Approx( data2.outgoingEnergy(1) ) );
-  CHECK( 15. == Approx( data2.outgoingEnergy(2) ) );
+  CHECK_THAT( 1.1, WithinRel( data2.outgoingEnergy(1) ) );
+  CHECK_THAT( 15., WithinRel( data2.outgoingEnergy(2) ) );
 
-  CHECK( 0.5 == Approx( data2.probability(1) ) );
-  CHECK( 0.5 == Approx( data2.probability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( data2.probability(1) ) );
+  CHECK_THAT( 0.5, WithinRel( data2.probability(2) ) );
 
-  CHECK( 0.5 == Approx( data2.cumulativeProbability(1) ) );
-  CHECK( 1.0 == Approx( data2.cumulativeProbability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( data2.cumulativeProbability(1) ) );
+  CHECK_THAT( 1.0, WithinRel( data2.cumulativeProbability(2) ) );
 
   CHECK( 66 == data2.LOCC(1) );
   CHECK( 74 == data2.LOCC(2) );
@@ -260,40 +263,40 @@ void verifyChunk( const EnergyAngleDistributionData& chunk ) {
   CHECK( 19 == data2.relativeDistributionLocator(2) );
 
   auto data21 = data2.distribution(1);
-  CHECK( 1.1 == Approx( data21.energy() ) );
-  CHECK( 0.5 == Approx( data21.probability() ) );
-  CHECK( 0.5 == Approx( data21.cumulativeProbability() ) );
+  CHECK_THAT( 1.1, WithinRel( data21.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data21.probability() ) );
+  CHECK_THAT( 0.5, WithinRel( data21.cumulativeProbability() ) );
   CHECK( 1 == data21.interpolation() );
   CHECK( 2 == data21.numberCosines() );
 
   CHECK( 2 == data21.cosines().size() );
-  CHECK( -1. == Approx( data21.cosines().front() ) );
-  CHECK( +1. == Approx( data21.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data21.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data21.cosines().back() ) );
 
   CHECK( 2 == data21.pdf().size() );
-  CHECK( .5 == Approx( data21.pdf().front() ) );
-  CHECK( .5 == Approx( data21.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data21.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data21.pdf().back() ) );
 
   CHECK( 2 == data21.cdf().size() );
-  CHECK( 0. == Approx( data21.cdf().front() ) );
-  CHECK( 1. == Approx( data21.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data21.cdf().back() ) );
 
   auto data22 = data2.distribution(2);
-  CHECK( 15 == Approx( data22.energy() ) );
-  CHECK( 0.5 == Approx( data22.probability() ) );
-  CHECK( 1.0 == Approx( data22.cumulativeProbability() ) );
+  CHECK_THAT( 15, WithinRel( data22.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data22.probability() ) );
+  CHECK_THAT( 1.0, WithinRel( data22.cumulativeProbability() ) );
   CHECK( 2 == data22.interpolation() );
   CHECK( 3 == data22.numberCosines() );
 
   CHECK( 3 == data22.cosines().size() );
-  CHECK( -1. == Approx( data22.cosines().front() ) );
-  CHECK( +1. == Approx( data22.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data22.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data22.cosines().back() ) );
 
   CHECK( 3 == data22.pdf().size() );
-  CHECK( .5 == Approx( data22.pdf().front() ) );
-  CHECK( .5 == Approx( data22.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data22.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data22.pdf().back() ) );
 
   CHECK( 3 == data22.cdf().size() );
-  CHECK( 0. == Approx( data22.cdf().front() ) );
-  CHECK( 1. == Approx( data22.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data22.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data22.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/EnergyDependentWattSpectrum/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EnergyDependentWattSpectrum/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EnergyDependentWattSpectrum.test EnergyDependentWattSpectrum.test.cpp )
-target_compile_options( ACEtk.continuous.EnergyDependentWattSpectrum.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EnergyDependentWattSpectrum.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EnergyDependentWattSpectrum COMMAND ACEtk.continuous.EnergyDependentWattSpectrum.test )
+add_cpp_test( continuous.EnergyDependentWattSpectrum EnergyDependentWattSpectrum.test.cpp )

--- a/src/ACEtk/continuous/EnergyDependentWattSpectrum/test/EnergyDependentWattSpectrum.test.cpp
+++ b/src/ACEtk/continuous/EnergyDependentWattSpectrum/test/EnergyDependentWattSpectrum.test.cpp
@@ -1,7 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/continuous/ParameterData.hpp"
+// what we are testing
 #include "ACEtk/continuous/EnergyDependentWattSpectrum.hpp"
 
 // other includes
@@ -40,7 +42,7 @@ SCENARIO( "EnergyDependentWattSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +62,7 @@ SCENARIO( "EnergyDependentWattSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -102,16 +104,16 @@ void verifyChunk( const EnergyDependentWattSpectrum& chunk ) {
   CHECK( 4 == a.numberEnergyPoints() );
 
   CHECK( 4 == a.energies().size() );
-  CHECK( 1e-05 == Approx( a.energies()[0] ) );
-  CHECK( 1. == Approx( a.energies()[1] ) );
-  CHECK( 10. == Approx( a.energies()[2] ) );
-  CHECK( 20. == Approx( a.energies()[3] ) );
+  CHECK_THAT( 1e-05, WithinRel( a.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( a.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( a.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( a.energies()[3] ) );
 
   CHECK( 4 == a.values().size() );
-  CHECK( 1. == Approx( a.values()[0] ) );
-  CHECK( 2. == Approx( a.values()[1] ) );
-  CHECK( 3. == Approx( a.values()[2] ) );
-  CHECK( 4. == Approx( a.values()[3] ) );
+  CHECK_THAT( 1., WithinRel( a.values()[0] ) );
+  CHECK_THAT( 2., WithinRel( a.values()[1] ) );
+  CHECK_THAT( 3., WithinRel( a.values()[2] ) );
+  CHECK_THAT( 4., WithinRel( a.values()[3] ) );
 
   auto b = chunk.b();
   CHECK( 0 == b.interpolationData().NB() );
@@ -132,17 +134,17 @@ void verifyChunk( const EnergyDependentWattSpectrum& chunk ) {
   CHECK( 3 == b.numberEnergyPoints() );
 
   CHECK( 3 == b.energies().size() );
-  CHECK( 1e-05 == Approx( b.energies()[0] ) );
-  CHECK( 2. == Approx( b.energies()[1] ) );
-  CHECK( 20. == Approx( b.energies()[2] ) );
+  CHECK_THAT( 1e-05, WithinRel( b.energies()[0] ) );
+  CHECK_THAT( 2., WithinRel( b.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( b.energies()[2] ) );
 
   CHECK( 3 == b.values().size() );
-  CHECK( 5. == Approx( b.values()[0] ) );
-  CHECK( 6. == Approx( b.values()[1] ) );
-  CHECK( 7. == Approx( b.values()[2] ) );
+  CHECK_THAT( 5., WithinRel( b.values()[0] ) );
+  CHECK_THAT( 6., WithinRel( b.values()[1] ) );
+  CHECK_THAT( 7., WithinRel( b.values()[2] ) );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 1.5e+6 == chunk.U() );
   CHECK( 1.5e+6 == chunk.restrictionEnergy() );

--- a/src/ACEtk/continuous/EnergyDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EnergyDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EnergyDistributionBlock.test EnergyDistributionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.EnergyDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EnergyDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EnergyDistributionBlock COMMAND ACEtk.continuous.EnergyDistributionBlock.test )
+add_cpp_test( continuous.EnergyDistributionBlock EnergyDistributionBlock.test.cpp )

--- a/src/ACEtk/continuous/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
+++ b/src/ACEtk/continuous/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EnergyDistributionBlock.hpp"
 
 // other includes
@@ -67,7 +70,7 @@ SCENARIO( "EnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,7 +94,7 @@ SCENARIO( "EnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -152,10 +155,10 @@ void verifyChunk( const EnergyDistributionBlock& chunk ) {
   auto data1 = std::get< LevelScatteringDistribution >( chunk.energyDistributionData(1) );
   CHECK( EnergyDistributionType::LevelScattering == data1.LAW() );
   CHECK( EnergyDistributionType::LevelScattering == data1.type() );
-  CHECK( 2.249999e-3 == Approx( data1.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( data1.maximumIncidentEnergy() ) );
-  CHECK( 7.71295800000E-05 == Approx( data1.C1() ) );
-  CHECK( .9914722 == Approx( data1.C2() ) );
+  CHECK_THAT( 2.249999e-3, WithinRel( data1.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data1.maximumIncidentEnergy() ) );
+  CHECK_THAT( 7.71295800000E-05, WithinRel( data1.C1() ) );
+  CHECK_THAT( .9914722, WithinRel( data1.C2() ) );
 
   auto data2 = std::get< KalbachMannDistributionData >( chunk.energyDistributionData(2) );
   CHECK( EnergyDistributionType::KalbachMann == data2.LAW() );
@@ -163,12 +166,12 @@ void verifyChunk( const EnergyDistributionBlock& chunk ) {
   CHECK( 2 == data2.NE() );
   CHECK( 2 == data2.numberIncidentEnergies() );
   CHECK( 2 == data2.incidentEnergies().size() );
-  CHECK( 1.219437E+01 == Approx( data2.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( data2.incidentEnergies()[1] ) );
-  CHECK( 1.219437E+01 == Approx( data2.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( data2.incidentEnergy(2) ) );
-  CHECK( 1.219437E+01 == Approx( data2.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( data2.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergies()[1] ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy(2) ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.maximumIncidentEnergy() ) );
   CHECK( 33 == data2.LOCC(1) );
   CHECK( 45 == data2.LOCC(2) );
   CHECK( 33 == data2.distributionLocator(1) );
@@ -176,45 +179,45 @@ void verifyChunk( const EnergyDistributionBlock& chunk ) {
   CHECK( 7 == data2.relativeDistributionLocator(1) );
   CHECK( 19 == data2.relativeDistributionLocator(2) );
   auto data21 = data2.distribution(1);
-  CHECK( 1.219437E+01 == Approx( data21.incidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data21.incidentEnergy() ) );
   CHECK( 1 == data21.interpolation() );
   CHECK( 0 == data21.numberDiscretePhotonLines() );
   CHECK( 2 == data21.numberOutgoingEnergies() );
   CHECK( 2 == data21.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data21.outgoingEnergies().front() ) );
-  CHECK( 1.866919E-02 == Approx( data21.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data21.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.866919E-02, WithinRel( data21.outgoingEnergies().back() ) );
   CHECK( 2 == data21.pdf().size() );
-  CHECK( 5.356419E+01 == Approx( data21.pdf().front() ) );
-  CHECK( 0. == Approx( data21.pdf().back() ) );
+  CHECK_THAT( 5.356419E+01, WithinRel( data21.pdf().front() ) );
+  CHECK_THAT( 0., WithinRel( data21.pdf().back() ) );
   CHECK( 2 == data21.cdf().size() );
-  CHECK( 0. == Approx( data21.cdf().front() ) );
-  CHECK( 1. == Approx( data21.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data21.cdf().back() ) );
   CHECK( 2 == data21.precompoundFractionValues().size() );
-  CHECK( 0. == Approx( data21.precompoundFractionValues().front() ) );
-  CHECK( 0. == Approx( data21.precompoundFractionValues().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.precompoundFractionValues().front() ) );
+  CHECK_THAT( 0., WithinRel( data21.precompoundFractionValues().back() ) );
   CHECK( 2 == data21.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data21.angularDistributionSlopeValues().front() ) );
-  CHECK( 2.398743E-01 == Approx( data21.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data21.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 2.398743E-01, WithinRel( data21.angularDistributionSlopeValues().back() ) );
   auto data22 = data2.distribution(2);
-  CHECK( 20. == Approx( data22.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data22.incidentEnergy() ) );
   CHECK( 2 == data22.interpolation() );
   CHECK( 0 == data22.numberDiscretePhotonLines() );
   CHECK( 3 == data22.numberOutgoingEnergies() );
   CHECK( 3 == data22.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data22.outgoingEnergies().front() ) );
-  CHECK( 7.592137E+00 == Approx( data22.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data22.outgoingEnergies().front() ) );
+  CHECK_THAT( 7.592137E+00, WithinRel( data22.outgoingEnergies().back() ) );
   CHECK( 3 == data22.pdf().size() );
-  CHECK( 7.738696E-02 == Approx( data22.pdf().front() ) );
-  CHECK( 1.226090E-11 == Approx( data22.pdf().back() ) );
+  CHECK_THAT( 7.738696E-02, WithinRel( data22.pdf().front() ) );
+  CHECK_THAT( 1.226090E-11, WithinRel( data22.pdf().back() ) );
   CHECK( 3 == data22.cdf().size() );
-  CHECK( 0. == Approx( data22.cdf().front() ) );
-  CHECK( 1. == Approx( data22.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data22.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data22.cdf().back() ) );
   CHECK( 3 == data22.precompoundFractionValues().size() );
-  CHECK( 2.491475E-03 == Approx( data22.precompoundFractionValues().front() ) );
-  CHECK( 9.775367E-01 == Approx( data22.precompoundFractionValues().back() ) );
+  CHECK_THAT( 2.491475E-03, WithinRel( data22.precompoundFractionValues().front() ) );
+  CHECK_THAT( 9.775367E-01, WithinRel( data22.precompoundFractionValues().back() ) );
   CHECK( 3 == data22.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data22.angularDistributionSlopeValues().front() ) );
-  CHECK( 5.592013E-01 == Approx( data22.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data22.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 5.592013E-01, WithinRel( data22.angularDistributionSlopeValues().back() ) );
 
   CHECK( ReferenceFrame::Laboratory == chunk.referenceFrame(1) );
   CHECK( ReferenceFrame::CentreOfMass == chunk.referenceFrame(2) );
@@ -241,18 +244,18 @@ void verifyChunk( const EnergyDistributionBlock& chunk ) {
   CHECK( 2 == multiplicity1.numberEnergyPoints() );
 
   CHECK( 2 == multiplicity1.energies().size() );
-  CHECK( 1e-11 == Approx( multiplicity1.energies()[0] ) );
-  CHECK( 20. == Approx( multiplicity1.energies()[1] ) );
+  CHECK_THAT( 1e-11, WithinRel( multiplicity1.energies()[0] ) );
+  CHECK_THAT( 20., WithinRel( multiplicity1.energies()[1] ) );
 
   CHECK( 2 == multiplicity1.multiplicities().size() );
-  CHECK( 1. == Approx( multiplicity1.multiplicities()[0] ) );
-  CHECK( 1. == Approx( multiplicity1.multiplicities()[1] ) );
+  CHECK_THAT( 1., WithinRel( multiplicity1.multiplicities()[0] ) );
+  CHECK_THAT( 1., WithinRel( multiplicity1.multiplicities()[1] ) );
 
   auto multiplicity2 = std::get< unsigned int >( chunk.multiplicityData(2) );
   CHECK( 1 == multiplicity2 );
 
   decltype(auto) tyr = chunk.tyrMultiplicities();
   CHECK( 2 == tyr.size() );
-  CHECK( 101 == Approx( tyr[0] ) );
-  CHECK( 1 == Approx( tyr[1] ) );
+  CHECK( 101 == tyr[0] );
+  CHECK( 1 == tyr[1] );
 }

--- a/src/ACEtk/continuous/EquiprobableAngularBins/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EquiprobableAngularBins/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EquiprobableAngularBins.test EquiprobableAngularBins.test.cpp )
-target_compile_options( ACEtk.continuous.EquiprobableAngularBins.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EquiprobableAngularBins.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EquiprobableAngularBins COMMAND ACEtk.continuous.EquiprobableAngularBins.test )
+add_cpp_test( continuous.EquiprobableAngularBins EquiprobableAngularBins.test.cpp )

--- a/src/ACEtk/continuous/EquiprobableAngularBins/test/EquiprobableAngularBins.test.cpp
+++ b/src/ACEtk/continuous/EquiprobableAngularBins/test/EquiprobableAngularBins.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EquiprobableAngularBins.hpp"
 
 // other includes
@@ -42,7 +45,7 @@ SCENARIO( "EquiprobableAngularBins" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -62,7 +65,7 @@ SCENARIO( "EquiprobableAngularBins" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,10 +94,10 @@ void verifyChunk( const EquiprobableAngularBins& chunk ) {
   CHECK( 33 == chunk.length() );
   CHECK( "EquiprobableAngularBins" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
   CHECK( 32 == chunk.numberBins() );
 
   CHECK( 33 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines().front() ) );
-  CHECK( +1. == Approx( chunk.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( chunk.cosines().back() ) );
 }

--- a/src/ACEtk/continuous/EquiprobableOutgoingEnergyBinData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EquiprobableOutgoingEnergyBinData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EquiprobableOutgoingEnergyBinData.test EquiprobableOutgoingEnergyBinData.test.cpp )
-target_compile_options( ACEtk.continuous.EquiprobableOutgoingEnergyBinData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EquiprobableOutgoingEnergyBinData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EquiprobableOutgoingEnergyBinData COMMAND ACEtk.continuous.EquiprobableOutgoingEnergyBinData.test )
+add_cpp_test( continuous.EquiprobableOutgoingEnergyBinData EquiprobableOutgoingEnergyBinData.test.cpp )

--- a/src/ACEtk/continuous/EquiprobableOutgoingEnergyBinData/test/EquiprobableOutgoingEnergyBinData.test.cpp
+++ b/src/ACEtk/continuous/EquiprobableOutgoingEnergyBinData/test/EquiprobableOutgoingEnergyBinData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EquiprobableOutgoingEnergyBinData.hpp"
 
 // other includes
@@ -40,7 +43,7 @@ SCENARIO( "EquiprobableOutgoingEnergyBinData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "EquiprobableOutgoingEnergyBinData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -107,14 +110,14 @@ void verifyChunk( const EquiprobableOutgoingEnergyBinData& chunk ) {
   CHECK( 2 == chunk.numberIncidentEnergies() );
 
   CHECK( 2 == chunk.incidentEnergies().size() );
-  CHECK( 1e-05 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-05, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[1] ) );
 
-  CHECK( 1e-5 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(2) ) );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 4 == chunk.NET() );
   CHECK( 3 == chunk.numberBins() );
@@ -122,37 +125,37 @@ void verifyChunk( const EquiprobableOutgoingEnergyBinData& chunk ) {
   decltype(auto) distributions = chunk.distributions();
   CHECK( 2 == distributions.size() );
 
-  CHECK( 1e-5 == Approx( distributions[0].incidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( distributions[0].incidentEnergy() ) );
   CHECK( 3 == distributions[0].numberBins() );
   CHECK( 4 == distributions[0].energies().size() );
-  CHECK( 1e-4 == Approx( distributions[0].energies()[0] ) );
-  CHECK( 1. == Approx( distributions[0].energies()[1] ) );
-  CHECK( 10. == Approx( distributions[0].energies()[2] ) );
-  CHECK( 20. == Approx( distributions[0].energies()[3] ) );
+  CHECK_THAT( 1e-4, WithinRel( distributions[0].energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( distributions[0].energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( distributions[0].energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( distributions[0].energies()[3] ) );
 
-  CHECK( 20. == Approx( distributions[1].incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( distributions[1].incidentEnergy() ) );
   CHECK( 3 == distributions[1].numberBins() );
   CHECK( 4 == distributions[1].energies().size() );
-  CHECK( 1e-5 == Approx( distributions[1].energies()[0] ) );
-  CHECK( 3. == Approx( distributions[1].energies()[1] ) );
-  CHECK( 12. == Approx( distributions[1].energies()[2] ) );
-  CHECK( 20. == Approx( distributions[1].energies()[3] ) );
+  CHECK_THAT( 1e-5, WithinRel( distributions[1].energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( distributions[1].energies()[1] ) );
+  CHECK_THAT( 12., WithinRel( distributions[1].energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( distributions[1].energies()[3] ) );
 
   auto bins1 = chunk.distribution(1);
-  CHECK( 1e-5 == Approx( bins1.incidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( bins1.incidentEnergy() ) );
   CHECK( 3 == bins1.numberBins() );
   CHECK( 4 == bins1.energies().size() );
-  CHECK( 1e-4 == Approx( bins1.energies()[0] ) );
-  CHECK( 1. == Approx( bins1.energies()[1] ) );
-  CHECK( 10. == Approx( bins1.energies()[2] ) );
-  CHECK( 20. == Approx( bins1.energies()[3] ) );
+  CHECK_THAT( 1e-4, WithinRel( bins1.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( bins1.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( bins1.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( bins1.energies()[3] ) );
 
   auto bins2 = chunk.distribution(2);
-  CHECK( 20. == Approx( bins2.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( bins2.incidentEnergy() ) );
   CHECK( 3 == bins2.numberBins() );
   CHECK( 4 == bins2.energies().size() );
-  CHECK( 1e-5 == Approx( bins2.energies()[0] ) );
-  CHECK( 3. == Approx( bins2.energies()[1] ) );
-  CHECK( 12. == Approx( bins2.energies()[2] ) );
-  CHECK( 20. == Approx( bins2.energies()[3] ) );
+  CHECK_THAT( 1e-5, WithinRel( bins2.energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( bins2.energies()[1] ) );
+  CHECK_THAT( 12., WithinRel( bins2.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( bins2.energies()[3] ) );
 }

--- a/src/ACEtk/continuous/EquiprobableOutgoingEnergyBins/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EquiprobableOutgoingEnergyBins/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EquiprobableOutgoingEnergyBins.test EquiprobableOutgoingEnergyBins.test.cpp )
-target_compile_options( ACEtk.continuous.EquiprobableOutgoingEnergyBins.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EquiprobableOutgoingEnergyBins.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EquiprobableOutgoingEnergyBins COMMAND ACEtk.continuous.EquiprobableOutgoingEnergyBins.test )
+add_cpp_test( continuous.EquiprobableOutgoingEnergyBins EquiprobableOutgoingEnergyBins.test.cpp )

--- a/src/ACEtk/continuous/EquiprobableOutgoingEnergyBins/test/EquiprobableOutgoingEnergyBins.test.cpp
+++ b/src/ACEtk/continuous/EquiprobableOutgoingEnergyBins/test/EquiprobableOutgoingEnergyBins.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EquiprobableOutgoingEnergyBins.hpp"
 
 // other includes
@@ -36,7 +39,7 @@ SCENARIO( "EquiprobableOutgoingEnergyBins" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -56,7 +59,7 @@ SCENARIO( "EquiprobableOutgoingEnergyBins" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -77,12 +80,12 @@ void verifyChunk( const EquiprobableOutgoingEnergyBins& chunk ) {
   CHECK( 4 == chunk.length() );
   CHECK( "EquiprobableOutgoingEnergyBins" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.incidentEnergy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.incidentEnergy() ) );
   CHECK( 3 == chunk.numberBins() );
 
   CHECK( 4 == chunk.energies().size() );
-  CHECK( 1e-5 == Approx( chunk.energies()[0] ) );
-  CHECK( .02 == Approx( chunk.energies()[1] ) );
-  CHECK( 1. == Approx( chunk.energies()[2] ) );
-  CHECK( 20. == Approx( chunk.energies()[3] ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( .02, WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[3] ) );
 }

--- a/src/ACEtk/continuous/EvaporationSpectrum/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/EvaporationSpectrum/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.EvaporationSpectrum.test EvaporationSpectrum.test.cpp )
-target_compile_options( ACEtk.continuous.EvaporationSpectrum.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.EvaporationSpectrum.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.EvaporationSpectrum COMMAND ACEtk.continuous.EvaporationSpectrum.test )
+add_cpp_test( continuous.EvaporationSpectrum EvaporationSpectrum.test.cpp )

--- a/src/ACEtk/continuous/EvaporationSpectrum/test/EvaporationSpectrum.test.cpp
+++ b/src/ACEtk/continuous/EvaporationSpectrum/test/EvaporationSpectrum.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/EvaporationSpectrum.hpp"
 
 // other includes
@@ -39,7 +42,7 @@ SCENARIO( "EvaporationSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "EvaporationSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -100,19 +103,19 @@ void verifyChunk( const EvaporationSpectrum& chunk ) {
   CHECK( 4 == chunk.numberEnergyPoints() );
 
   CHECK( 4 == chunk.energies().size() );
-  CHECK( 1e-05 == Approx( chunk.energies()[0] ) );
-  CHECK( 1. == Approx( chunk.energies()[1] ) );
-  CHECK( 10. == Approx( chunk.energies()[2] ) );
-  CHECK( 20. == Approx( chunk.energies()[3] ) );
+  CHECK_THAT( 1e-05, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( chunk.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[3] ) );
 
   CHECK( 4 == chunk.temperatures().size() );
-  CHECK( 1. == Approx( chunk.temperatures()[0] ) );
-  CHECK( 2. == Approx( chunk.temperatures()[1] ) );
-  CHECK( 3. == Approx( chunk.temperatures()[2] ) );
-  CHECK( 4. == Approx( chunk.temperatures()[3] ) );
+  CHECK_THAT( 1., WithinRel( chunk.temperatures()[0] ) );
+  CHECK_THAT( 2., WithinRel( chunk.temperatures()[1] ) );
+  CHECK_THAT( 3., WithinRel( chunk.temperatures()[2] ) );
+  CHECK_THAT( 4., WithinRel( chunk.temperatures()[3] ) );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 1.5e+6 == chunk.U() );
   CHECK( 1.5e+6 == chunk.restrictionEnergy() );

--- a/src/ACEtk/continuous/FissionMultiplicityBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/FissionMultiplicityBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.FissionMultiplicityBlock.test FissionMultiplicityBlock.test.cpp )
-target_compile_options( ACEtk.continuous.FissionMultiplicityBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.FissionMultiplicityBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.FissionMultiplicityBlock COMMAND ACEtk.continuous.FissionMultiplicityBlock.test )
+add_cpp_test( continuous.FissionMultiplicityBlock FissionMultiplicityBlock.test.cpp )

--- a/src/ACEtk/continuous/FissionMultiplicityBlock/test/FissionMultiplicityBlock.test.cpp
+++ b/src/ACEtk/continuous/FissionMultiplicityBlock/test/FissionMultiplicityBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/FissionMultiplicityBlock.hpp"
 
 // other includes
@@ -38,7 +41,7 @@ SCENARIO( "FissionMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +60,7 @@ SCENARIO( "FissionMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -85,7 +88,7 @@ SCENARIO( "FissionMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -104,7 +107,7 @@ SCENARIO( "FissionMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -152,14 +155,14 @@ void verifyChunk( const FissionMultiplicityBlock& chunk ) {
   CHECK( 3 == multiplicity.numberValues() );
 
   CHECK( 3 == multiplicity.energies().size() );
-  CHECK( 1e-11 == Approx( multiplicity.energies()[0] ) );
-  CHECK( 1. == Approx( multiplicity.energies()[1] ) );
-  CHECK( 20. == Approx( multiplicity.energies()[2] ) );
+  CHECK_THAT( 1e-11, WithinRel( multiplicity.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( multiplicity.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( multiplicity.energies()[2] ) );
 
   CHECK( 3 == multiplicity.multiplicities().size() );
-  CHECK( 2.5 == Approx( multiplicity.multiplicities()[0] ) );
-  CHECK( 2.65 == Approx( multiplicity.multiplicities()[1] ) );
-  CHECK( 3.5 == Approx( multiplicity.multiplicities()[2] ) );
+  CHECK_THAT( 2.5, WithinRel( multiplicity.multiplicities()[0] ) );
+  CHECK_THAT( 2.65, WithinRel( multiplicity.multiplicities()[1] ) );
+  CHECK_THAT( 3.5, WithinRel( multiplicity.multiplicities()[2] ) );
 
   CHECK( std::nullopt == chunk.totalFissionMultiplicity() );
 }
@@ -194,14 +197,14 @@ void verifyChunkWithPromptAndTotal( const FissionMultiplicityBlock& chunk ) {
   CHECK( 3 == multiplicity.numberValues() );
 
   CHECK( 3 == multiplicity.energies().size() );
-  CHECK( 1e-11 == Approx( multiplicity.energies()[0] ) );
-  CHECK( 1. == Approx( multiplicity.energies()[1] ) );
-  CHECK( 20. == Approx( multiplicity.energies()[2] ) );
+  CHECK_THAT( 1e-11, WithinRel( multiplicity.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( multiplicity.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( multiplicity.energies()[2] ) );
 
   CHECK( 3 == multiplicity.multiplicities().size() );
-  CHECK( 2.5 == Approx( multiplicity.multiplicities()[0] ) );
-  CHECK( 2.65 == Approx( multiplicity.multiplicities()[1] ) );
-  CHECK( 3.5 == Approx( multiplicity.multiplicities()[2] ) );
+  CHECK_THAT( 2.5, WithinRel( multiplicity.multiplicities()[0] ) );
+  CHECK_THAT( 2.65, WithinRel( multiplicity.multiplicities()[1] ) );
+  CHECK_THAT( 3.5, WithinRel( multiplicity.multiplicities()[2] ) );
 
   auto total = std::get< PolynomialFissionMultiplicity >( chunk.totalFissionMultiplicity().value() );
   CHECK( 1 == total.LNU() );
@@ -211,6 +214,6 @@ void verifyChunkWithPromptAndTotal( const FissionMultiplicityBlock& chunk ) {
   CHECK( 2 == total.numberCoefficients() );
 
   CHECK( 2 == total.coefficients().size() );
-  CHECK( 2.35 == Approx( total.coefficients()[0] ) );
-  CHECK( 1e-3 == Approx( total.coefficients()[1] ) );
+  CHECK_THAT( 2.35, WithinRel( total.coefficients()[0] ) );
+  CHECK_THAT( 1e-3, WithinRel( total.coefficients()[1] ) );
 }

--- a/src/ACEtk/continuous/FrameAndMultiplicityBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/FrameAndMultiplicityBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.FrameAndMultiplicityBlock.test FrameAndMultiplicityBlock.test.cpp )
-target_compile_options( ACEtk.continuous.FrameAndMultiplicityBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.FrameAndMultiplicityBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.FrameAndMultiplicityBlock COMMAND ACEtk.continuous.FrameAndMultiplicityBlock.test )
+add_cpp_test( continuous.FrameAndMultiplicityBlock FrameAndMultiplicityBlock.test.cpp )

--- a/src/ACEtk/continuous/FrameAndMultiplicityBlock/test/FrameAndMultiplicityBlock.test.cpp
+++ b/src/ACEtk/continuous/FrameAndMultiplicityBlock/test/FrameAndMultiplicityBlock.test.cpp
@@ -1,7 +1,10 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
-#include "ACEtk/continuous/FrameAndMultiplicityBlock.hpp"
+// what we are testing
+#include "ACEtk/continuous/EnergyDistributionBlock.hpp"
 
 // other includes
 
@@ -44,7 +47,7 @@ SCENARIO( "FrameAndMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -64,7 +67,7 @@ SCENARIO( "FrameAndMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -96,7 +99,7 @@ SCENARIO( "FrameAndMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -116,7 +119,7 @@ SCENARIO( "FrameAndMultiplicityBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/GeneralEvaporationSpectrum/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/GeneralEvaporationSpectrum/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.GeneralEvaporationSpectrum.test GeneralEvaporationSpectrum.test.cpp )
-target_compile_options( ACEtk.continuous.GeneralEvaporationSpectrum.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.GeneralEvaporationSpectrum.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.GeneralEvaporationSpectrum COMMAND ACEtk.continuous.GeneralEvaporationSpectrum.test )
+add_cpp_test( continuous.GeneralEvaporationSpectrum GeneralEvaporationSpectrum.test.cpp )

--- a/src/ACEtk/continuous/GeneralEvaporationSpectrum/test/GeneralEvaporationSpectrum.test.cpp
+++ b/src/ACEtk/continuous/GeneralEvaporationSpectrum/test/GeneralEvaporationSpectrum.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/GeneralEvaporationSpectrum.hpp"
 
 // other includes
@@ -39,7 +42,7 @@ SCENARIO( "GeneralEvaporationSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -58,7 +61,7 @@ SCENARIO( "GeneralEvaporationSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -99,25 +102,25 @@ void verifyChunk( const GeneralEvaporationSpectrum& chunk ) {
   CHECK( 4 == chunk.numberEnergyPoints() );
 
   CHECK( 4 == chunk.energies().size() );
-  CHECK( 1e-05 == Approx( chunk.energies()[0] ) );
-  CHECK( 1. == Approx( chunk.energies()[1] ) );
-  CHECK( 10. == Approx( chunk.energies()[2] ) );
-  CHECK( 20. == Approx( chunk.energies()[3] ) );
+  CHECK_THAT( 1e-05, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( chunk.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[3] ) );
 
   CHECK( 4 == chunk.temperatures().size() );
-  CHECK( 1. == Approx( chunk.temperatures()[0] ) );
-  CHECK( 2. == Approx( chunk.temperatures()[1] ) );
-  CHECK( 3. == Approx( chunk.temperatures()[2] ) );
-  CHECK( 4. == Approx( chunk.temperatures()[3] ) );
+  CHECK_THAT( 1., WithinRel( chunk.temperatures()[0] ) );
+  CHECK_THAT( 2., WithinRel( chunk.temperatures()[1] ) );
+  CHECK_THAT( 3., WithinRel( chunk.temperatures()[2] ) );
+  CHECK_THAT( 4., WithinRel( chunk.temperatures()[3] ) );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 3 == chunk.NET() );
   CHECK( 2 == chunk.numberBins() );
 
   CHECK( 3 == chunk.bins().size() );
-  CHECK( 5. == Approx( chunk.bins()[0] ) );
-  CHECK( 6. == Approx( chunk.bins()[1] ) );
-  CHECK( 7. == Approx( chunk.bins()[2] ) );
+  CHECK_THAT( 5., WithinRel( chunk.bins()[0] ) );
+  CHECK_THAT( 6., WithinRel( chunk.bins()[1] ) );
+  CHECK_THAT( 7., WithinRel( chunk.bins()[2] ) );
 }

--- a/src/ACEtk/continuous/IsotropicAngularDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/IsotropicAngularDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.IsotropicAngularDistribution.test IsotropicAngularDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.IsotropicAngularDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.IsotropicAngularDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.IsotropicAngularDistribution COMMAND ACEtk.continuous.IsotropicAngularDistribution.test )
+add_cpp_test( continuous.IsotropicAngularDistribution IsotropicAngularDistribution.test.cpp )

--- a/src/ACEtk/continuous/IsotropicAngularDistribution/test/IsotropicAngularDistribution.test.cpp
+++ b/src/ACEtk/continuous/IsotropicAngularDistribution/test/IsotropicAngularDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/IsotropicAngularDistribution.hpp"
 
 // other includes
@@ -32,5 +35,5 @@ SCENARIO( "IsotropicAngularDistribution" ) {
 
 void verifyChunk( const IsotropicAngularDistribution& chunk ) {
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
 }

--- a/src/ACEtk/continuous/KalbachMannDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/KalbachMannDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.KalbachMannDistributionData.test KalbachMannDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.KalbachMannDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.KalbachMannDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.KalbachMannDistributionData COMMAND ACEtk.continuous.KalbachMannDistributionData.test )
+add_cpp_test( continuous.KalbachMannDistributionData KalbachMannDistributionData.test.cpp )

--- a/src/ACEtk/continuous/KalbachMannDistributionData/test/KalbachMannDistributionData.test.cpp
+++ b/src/ACEtk/continuous/KalbachMannDistributionData/test/KalbachMannDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/KalbachMannDistributionData.hpp"
 
 // other includes
@@ -49,7 +52,7 @@ SCENARIO( "KalbachMannDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -69,7 +72,7 @@ SCENARIO( "KalbachMannDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -115,14 +118,14 @@ void verifyChunk( const KalbachMannDistributionData& chunk ) {
   CHECK( 2 == chunk.numberIncidentEnergies() );
 
   CHECK( 2 == chunk.incidentEnergies().size() );
-  CHECK( 1.219437E+01 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[1] ) );
 
-  CHECK( 1.219437E+01 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(2) ) );
 
-  CHECK( 1.219437E+01 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 27 == chunk.LOCC(1) );
   CHECK( 39 == chunk.LOCC(2) );
@@ -133,54 +136,54 @@ void verifyChunk( const KalbachMannDistributionData& chunk ) {
   CHECK( 19 == chunk.relativeDistributionLocator(2) );
 
   auto data1 = chunk.distribution(1);
-  CHECK( 1.219437E+01 == Approx( data1.incidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data1.incidentEnergy() ) );
   CHECK( 1 == data1.interpolation() );
   CHECK( 0 == data1.numberDiscretePhotonLines() );
   CHECK( 2 == data1.numberOutgoingEnergies() );
 
   CHECK( 2 == data1.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data1.outgoingEnergies().front() ) );
-  CHECK( 1.866919E-02 == Approx( data1.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data1.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.866919E-02, WithinRel( data1.outgoingEnergies().back() ) );
 
   CHECK( 2 == data1.pdf().size() );
-  CHECK( 5.356419E+01 == Approx( data1.pdf().front() ) );
-  CHECK( 0. == Approx( data1.pdf().back() ) );
+  CHECK_THAT( 5.356419E+01, WithinRel( data1.pdf().front() ) );
+  CHECK_THAT( 0., WithinRel( data1.pdf().back() ) );
 
   CHECK( 2 == data1.cdf().size() );
-  CHECK( 0. == Approx( data1.cdf().front() ) );
-  CHECK( 1. == Approx( data1.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data1.cdf().back() ) );
 
   CHECK( 2 == data1.precompoundFractionValues().size() );
-  CHECK( 0. == Approx( data1.precompoundFractionValues().front() ) );
-  CHECK( 0. == Approx( data1.precompoundFractionValues().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.precompoundFractionValues().front() ) );
+  CHECK_THAT( 0., WithinRel( data1.precompoundFractionValues().back() ) );
 
   CHECK( 2 == data1.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data1.angularDistributionSlopeValues().front() ) );
-  CHECK( 2.398743E-01 == Approx( data1.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data1.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 2.398743E-01, WithinRel( data1.angularDistributionSlopeValues().back() ) );
 
   auto data2 = chunk.distribution(2);
-  CHECK( 20. == Approx( data2.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy() ) );
   CHECK( 2 == data2.interpolation() );
   CHECK( 0 == data2.numberDiscretePhotonLines() );
   CHECK( 3 == data2.numberOutgoingEnergies() );
 
   CHECK( 3 == data2.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data2.outgoingEnergies().front() ) );
-  CHECK( 7.592137E+00 == Approx( data2.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data2.outgoingEnergies().front() ) );
+  CHECK_THAT( 7.592137E+00, WithinRel( data2.outgoingEnergies().back() ) );
 
   CHECK( 3 == data2.pdf().size() );
-  CHECK( 7.738696E-02 == Approx( data2.pdf().front() ) );
-  CHECK( 1.226090E-11 == Approx( data2.pdf().back() ) );
+  CHECK_THAT( 7.738696E-02, WithinRel( data2.pdf().front() ) );
+  CHECK_THAT( 1.226090E-11, WithinRel( data2.pdf().back() ) );
 
   CHECK( 3 == data2.cdf().size() );
-  CHECK( 0. == Approx( data2.cdf().front() ) );
-  CHECK( 1. == Approx( data2.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data2.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data2.cdf().back() ) );
 
   CHECK( 3 == data2.precompoundFractionValues().size() );
-  CHECK( 2.491475E-03 == Approx( data2.precompoundFractionValues().front() ) );
-  CHECK( 9.775367E-01 == Approx( data2.precompoundFractionValues().back() ) );
+  CHECK_THAT( 2.491475E-03, WithinRel( data2.precompoundFractionValues().front() ) );
+  CHECK_THAT( 9.775367E-01, WithinRel( data2.precompoundFractionValues().back() ) );
 
   CHECK( 3 == data2.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data2.angularDistributionSlopeValues().front() ) );
-  CHECK( 5.592013E-01 == Approx( data2.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data2.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 5.592013E-01, WithinRel( data2.angularDistributionSlopeValues().back() ) );
 }

--- a/src/ACEtk/continuous/LevelScatteringDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/LevelScatteringDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.LevelScatteringDistribution.test LevelScatteringDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.LevelScatteringDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.LevelScatteringDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.LevelScatteringDistribution COMMAND ACEtk.continuous.LevelScatteringDistribution.test )
+add_cpp_test( continuous.LevelScatteringDistribution LevelScatteringDistribution.test.cpp )

--- a/src/ACEtk/continuous/LevelScatteringDistribution/test/LevelScatteringDistribution.test.cpp
+++ b/src/ACEtk/continuous/LevelScatteringDistribution/test/LevelScatteringDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/LevelScatteringDistribution.hpp"
 
 // other includes
@@ -38,7 +41,7 @@ SCENARIO( "LevelScatteringDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "LevelScatteringDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -80,9 +83,9 @@ void verifyChunk( const LevelScatteringDistribution& chunk ) {
   CHECK( EnergyDistributionType::LevelScattering == chunk.LAW() );
   CHECK( EnergyDistributionType::LevelScattering == chunk.type() );
 
-  CHECK( 2.249999e-3 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 2.249999e-3, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
-  CHECK( 7.71295800000E-05 == Approx( chunk.C1() ) );
-  CHECK( .9914722 == Approx( chunk.C2() ) );
+  CHECK_THAT( 7.71295800000E-05, WithinRel( chunk.C1() ) );
+  CHECK_THAT( .9914722, WithinRel( chunk.C2() ) );
 }

--- a/src/ACEtk/continuous/MultiDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/MultiDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.MultiDistributionData.test MultiDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.MultiDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.MultiDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.MultiDistributionData COMMAND ACEtk.continuous.MultiDistributionData.test )
+add_cpp_test( continuous.MultiDistributionData MultiDistributionData.test.cpp )

--- a/src/ACEtk/continuous/MultiDistributionData/test/MultiDistributionData.test.cpp
+++ b/src/ACEtk/continuous/MultiDistributionData/test/MultiDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/MultiDistributionData.hpp"
 
 // other includes
@@ -67,7 +70,7 @@ SCENARIO( "MultiDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -87,7 +90,7 @@ SCENARIO( "MultiDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -152,12 +155,12 @@ void verifyChunk( const MultiDistributionData& chunk ) {
   CHECK( 2 == probability1.numberEnergyPoints() );
 
   CHECK( 2 == probability1.energies().size() );
-  CHECK( 1.219437E+01 == Approx( probability1.energies()[0] ) );
-  CHECK( 20. == Approx( probability1.energies()[1] ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( probability1.energies()[0] ) );
+  CHECK_THAT( 20., WithinRel( probability1.energies()[1] ) );
 
   CHECK( 2 == probability1.probabilities().size() );
-  CHECK( 0.25 == Approx( probability1.probabilities()[0] ) );
-  CHECK( 0.75 == Approx( probability1.probabilities()[1] ) );
+  CHECK_THAT( 0.25, WithinRel( probability1.probabilities()[0] ) );
+  CHECK_THAT( 0.75, WithinRel( probability1.probabilities()[1] ) );
 
   auto probability2 = chunk.probability( 2 );
   CHECK( 0 == probability2.interpolationData().NB() );
@@ -178,12 +181,12 @@ void verifyChunk( const MultiDistributionData& chunk ) {
   CHECK( 2 == probability2.numberEnergyPoints() );
 
   CHECK( 2 == probability2.energies().size() );
-  CHECK( 1e-5 == Approx( probability2.energies()[0] ) );
-  CHECK( 20. == Approx( probability2.energies()[1] ) );
+  CHECK_THAT( 1e-5, WithinRel( probability2.energies()[0] ) );
+  CHECK_THAT( 20., WithinRel( probability2.energies()[1] ) );
 
   CHECK( 2 == probability2.probabilities().size() );
-  CHECK( 0.75 == Approx( probability2.probabilities()[0] ) );
-  CHECK( 0.25 == Approx( probability2.probabilities()[1] ) );
+  CHECK_THAT( 0.75, WithinRel( probability2.probabilities()[0] ) );
+  CHECK_THAT( 0.25, WithinRel( probability2.probabilities()[1] ) );
 
   CHECK( true == std::holds_alternative< KalbachMannDistributionData >( chunk.distribution( 1 ) ) );
   CHECK( true == std::holds_alternative< GeneralEvaporationSpectrum >( chunk.distribution( 2 ) ) );
@@ -209,14 +212,14 @@ void verifyChunk( const MultiDistributionData& chunk ) {
   CHECK( 2 == distribution1.numberIncidentEnergies() );
 
   CHECK( 2 == distribution1.incidentEnergies().size() );
-  CHECK( 1.219437E+01 == Approx( distribution1.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( distribution1.incidentEnergies()[1] ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( distribution1.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( distribution1.incidentEnergies()[1] ) );
 
-  CHECK( 1.219437E+01 == Approx( distribution1.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( distribution1.incidentEnergy(2) ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( distribution1.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( distribution1.incidentEnergy(2) ) );
 
-  CHECK( 1.219437E+01 == Approx( distribution1.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( distribution1.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( distribution1.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( distribution1.maximumIncidentEnergy() ) );
 
   CHECK( 27 == distribution1.LOCC(1) );
   CHECK( 39 == distribution1.LOCC(2) );
@@ -227,56 +230,56 @@ void verifyChunk( const MultiDistributionData& chunk ) {
   CHECK( 19 == distribution1.relativeDistributionLocator(2) );
 
   auto data1 = distribution1.distribution(1);
-  CHECK( 1.219437E+01 == Approx( data1.incidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data1.incidentEnergy() ) );
   CHECK( 1 == data1.interpolation() );
   CHECK( 0 == data1.numberDiscretePhotonLines() );
   CHECK( 2 == data1.numberOutgoingEnergies() );
 
   CHECK( 2 == data1.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data1.outgoingEnergies().front() ) );
-  CHECK( 1.866919E-02 == Approx( data1.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data1.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.866919E-02, WithinRel( data1.outgoingEnergies().back() ) );
 
   CHECK( 2 == data1.pdf().size() );
-  CHECK( 5.356419E+01 == Approx( data1.pdf().front() ) );
-  CHECK( 0. == Approx( data1.pdf().back() ) );
+  CHECK_THAT( 5.356419E+01, WithinRel( data1.pdf().front() ) );
+  CHECK_THAT( 0., WithinRel( data1.pdf().back() ) );
 
   CHECK( 2 == data1.cdf().size() );
-  CHECK( 0. == Approx( data1.cdf().front() ) );
-  CHECK( 1. == Approx( data1.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data1.cdf().back() ) );
 
   CHECK( 2 == data1.precompoundFractionValues().size() );
-  CHECK( 0. == Approx( data1.precompoundFractionValues().front() ) );
-  CHECK( 0. == Approx( data1.precompoundFractionValues().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.precompoundFractionValues().front() ) );
+  CHECK_THAT( 0., WithinRel( data1.precompoundFractionValues().back() ) );
 
   CHECK( 2 == data1.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data1.angularDistributionSlopeValues().front() ) );
-  CHECK( 2.398743E-01 == Approx( data1.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data1.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 2.398743E-01, WithinRel( data1.angularDistributionSlopeValues().back() ) );
 
   auto data2 = distribution1.distribution(2);
-  CHECK( 20. == Approx( data2.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy() ) );
   CHECK( 2 == data2.interpolation() );
   CHECK( 0 == data2.numberDiscretePhotonLines() );
   CHECK( 3 == data2.numberOutgoingEnergies() );
 
   CHECK( 3 == data2.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data2.outgoingEnergies().front() ) );
-  CHECK( 7.592137E+00 == Approx( data2.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data2.outgoingEnergies().front() ) );
+  CHECK_THAT( 7.592137E+00, WithinRel( data2.outgoingEnergies().back() ) );
 
   CHECK( 3 == data2.pdf().size() );
-  CHECK( 7.738696E-02 == Approx( data2.pdf().front() ) );
-  CHECK( 1.226090E-11 == Approx( data2.pdf().back() ) );
+  CHECK_THAT( 7.738696E-02, WithinRel( data2.pdf().front() ) );
+  CHECK_THAT( 1.226090E-11, WithinRel( data2.pdf().back() ) );
 
   CHECK( 3 == data2.cdf().size() );
-  CHECK( 0. == Approx( data2.cdf().front() ) );
-  CHECK( 1. == Approx( data2.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data2.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data2.cdf().back() ) );
 
   CHECK( 3 == data2.precompoundFractionValues().size() );
-  CHECK( 2.491475E-03 == Approx( data2.precompoundFractionValues().front() ) );
-  CHECK( 9.775367E-01 == Approx( data2.precompoundFractionValues().back() ) );
+  CHECK_THAT( 2.491475E-03, WithinRel( data2.precompoundFractionValues().front() ) );
+  CHECK_THAT( 9.775367E-01, WithinRel( data2.precompoundFractionValues().back() ) );
 
   CHECK( 3 == data2.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data2.angularDistributionSlopeValues().front() ) );
-  CHECK( 5.592013E-01 == Approx( data2.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data2.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 5.592013E-01, WithinRel( data2.angularDistributionSlopeValues().back() ) );
 
   auto distribution2 = std::get< GeneralEvaporationSpectrum >( chunk.distribution( 2 ) );
   CHECK( 0 == distribution2.interpolationData().NB() );
@@ -297,25 +300,25 @@ void verifyChunk( const MultiDistributionData& chunk ) {
   CHECK( 4 == distribution2.numberEnergyPoints() );
 
   CHECK( 4 == distribution2.energies().size() );
-  CHECK( 1e-05 == Approx( distribution2.energies()[0] ) );
-  CHECK( 1. == Approx( distribution2.energies()[1] ) );
-  CHECK( 10. == Approx( distribution2.energies()[2] ) );
-  CHECK( 20. == Approx( distribution2.energies()[3] ) );
+  CHECK_THAT( 1e-05, WithinRel( distribution2.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( distribution2.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( distribution2.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( distribution2.energies()[3] ) );
 
   CHECK( 4 == distribution2.temperatures().size() );
-  CHECK( 1. == Approx( distribution2.temperatures()[0] ) );
-  CHECK( 2. == Approx( distribution2.temperatures()[1] ) );
-  CHECK( 3. == Approx( distribution2.temperatures()[2] ) );
-  CHECK( 4. == Approx( distribution2.temperatures()[3] ) );
+  CHECK_THAT( 1., WithinRel( distribution2.temperatures()[0] ) );
+  CHECK_THAT( 2., WithinRel( distribution2.temperatures()[1] ) );
+  CHECK_THAT( 3., WithinRel( distribution2.temperatures()[2] ) );
+  CHECK_THAT( 4., WithinRel( distribution2.temperatures()[3] ) );
 
-  CHECK( 1e-5 == Approx( distribution2.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( distribution2.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( distribution2.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( distribution2.maximumIncidentEnergy() ) );
 
   CHECK( 3 == distribution2.NET() );
   CHECK( 2 == distribution2.numberBins() );
 
   CHECK( 3 == distribution2.bins().size() );
-  CHECK( 5. == Approx( distribution2.bins()[0] ) );
-  CHECK( 6. == Approx( distribution2.bins()[1] ) );
-  CHECK( 7. == Approx( distribution2.bins()[2] ) );
+  CHECK_THAT( 5., WithinRel( distribution2.bins()[0] ) );
+  CHECK_THAT( 6., WithinRel( distribution2.bins()[1] ) );
+  CHECK_THAT( 7., WithinRel( distribution2.bins()[2] ) );
 }

--- a/src/ACEtk/continuous/MultiplicityReactionNumberBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/MultiplicityReactionNumberBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.MultiplicityReactionNumberBlock.test MultiplicityReactionNumberBlock.test.cpp )
-target_compile_options( ACEtk.continuous.MultiplicityReactionNumberBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.MultiplicityReactionNumberBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.MultiplicityReactionNumberBlock COMMAND ACEtk.continuous.MultiplicityReactionNumberBlock.test )
+add_cpp_test( continuous.MultiplicityReactionNumberBlock MultiplicityReactionNumberBlock.test.cpp )

--- a/src/ACEtk/continuous/MultiplicityReactionNumberBlock/test/MultiplicityReactionNumberBlock.test.cpp
+++ b/src/ACEtk/continuous/MultiplicityReactionNumberBlock/test/MultiplicityReactionNumberBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/MultiplicityReactionNumberBlock.hpp"
 
 // other includes
@@ -35,7 +38,7 @@ SCENARIO( "MultiplicityReactionNumberBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -55,7 +58,7 @@ SCENARIO( "MultiplicityReactionNumberBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/NBodyPhaseSpaceDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/NBodyPhaseSpaceDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.NBodyPhaseSpaceDistribution.test NBodyPhaseSpaceDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.NBodyPhaseSpaceDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.NBodyPhaseSpaceDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.NBodyPhaseSpaceDistribution COMMAND ACEtk.continuous.NBodyPhaseSpaceDistribution.test )
+add_cpp_test( continuous.NBodyPhaseSpaceDistribution NBodyPhaseSpaceDistribution.test.cpp )

--- a/src/ACEtk/continuous/NBodyPhaseSpaceDistribution/test/NBodyPhaseSpaceDistribution.test.cpp
+++ b/src/ACEtk/continuous/NBodyPhaseSpaceDistribution/test/NBodyPhaseSpaceDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/NBodyPhaseSpaceDistribution.hpp"
 
 // other includes
@@ -46,7 +49,7 @@ SCENARIO( "NBodyPhaseSpaceDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -67,7 +70,7 @@ SCENARIO( "NBodyPhaseSpaceDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -92,26 +95,26 @@ void verifyChunk( const NBodyPhaseSpaceDistribution& chunk ) {
   CHECK( EnergyDistributionType::NBodyPhaseSpace == chunk.LAW() );
   CHECK( EnergyDistributionType::NBodyPhaseSpace == chunk.type() );
 
-  CHECK( 2.249999e-3 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 2.249999e-3, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 4 == chunk.NPSX() );
   CHECK( 4 == chunk.numberParticles() );
-  CHECK( .9914722 == Approx( chunk.AP() ) );
-  CHECK( .9914722 == Approx( chunk.totalMassRatio() ) );
+  CHECK_THAT( .9914722, WithinRel( chunk.AP() ) );
+  CHECK_THAT( .9914722, WithinRel( chunk.totalMassRatio() ) );
   CHECK( 2 == chunk.interpolation() );
   CHECK( 4 == chunk.numberValues() );
 
-  CHECK( 0. == Approx( chunk.values()[0] ) );
-  CHECK( .25 == Approx( chunk.values()[1] ) );
-  CHECK( .75 == Approx( chunk.values()[2] ) );
-  CHECK( 1. == Approx( chunk.values()[3] ) );
-  CHECK( 1. == Approx( chunk.pdf()[0] ) );
-  CHECK( 1. == Approx( chunk.pdf()[1] ) );
-  CHECK( 1. == Approx( chunk.pdf()[2] ) );
-  CHECK( 1. == Approx( chunk.pdf()[3] ) );
-  CHECK( 0. == Approx( chunk.cdf()[0] ) );
-  CHECK( .33 == Approx( chunk.cdf()[1] ) );
-  CHECK( .66 == Approx( chunk.cdf()[2] ) );
-  CHECK( 1. == Approx( chunk.cdf()[3] ) );
+  CHECK_THAT( 0., WithinRel( chunk.values()[0] ) );
+  CHECK_THAT( .25, WithinRel( chunk.values()[1] ) );
+  CHECK_THAT( .75, WithinRel( chunk.values()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.values()[3] ) );
+  CHECK_THAT( 1., WithinRel( chunk.pdf()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.pdf()[1] ) );
+  CHECK_THAT( 1., WithinRel( chunk.pdf()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.pdf()[3] ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf()[0] ) );
+  CHECK_THAT( .33, WithinRel( chunk.cdf()[1] ) );
+  CHECK_THAT( .66, WithinRel( chunk.cdf()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf()[3] ) );
 }

--- a/src/ACEtk/continuous/OutgoingEnergyDistributionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/OutgoingEnergyDistributionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.OutgoingEnergyDistributionData.test OutgoingEnergyDistributionData.test.cpp )
-target_compile_options( ACEtk.continuous.OutgoingEnergyDistributionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.OutgoingEnergyDistributionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.OutgoingEnergyDistributionData COMMAND ACEtk.continuous.OutgoingEnergyDistributionData.test )
+add_cpp_test( continuous.OutgoingEnergyDistributionData OutgoingEnergyDistributionData.test.cpp )

--- a/src/ACEtk/continuous/OutgoingEnergyDistributionData/test/OutgoingEnergyDistributionData.test.cpp
+++ b/src/ACEtk/continuous/OutgoingEnergyDistributionData/test/OutgoingEnergyDistributionData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/OutgoingEnergyDistributionData.hpp"
 
 // other includes
@@ -44,7 +47,7 @@ SCENARIO( "OutgoingEnergyDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -64,7 +67,7 @@ SCENARIO( "OutgoingEnergyDistributionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -109,14 +112,14 @@ void verifyChunk( const OutgoingEnergyDistributionData& chunk ) {
   CHECK( 2 == chunk.numberIncidentEnergies() );
 
   CHECK( 2 == chunk.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( chunk.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergies()[1] ) );
 
-  CHECK( 1e-11 == Approx( chunk.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.incidentEnergy(2) ) );
 
-  CHECK( 1e-11 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 27 == chunk.LOCC(1) );
   CHECK( 38 == chunk.LOCC(2) );
@@ -127,38 +130,38 @@ void verifyChunk( const OutgoingEnergyDistributionData& chunk ) {
   CHECK( 18 == chunk.relativeDistributionLocator(2) );
 
   auto data1 = chunk.distribution(1);
-  CHECK( 1e-11 == Approx( data1.energyOrCosine() ) );
+  CHECK_THAT( 1e-11, WithinRel( data1.energyOrCosine() ) );
   CHECK( 2 == data1.interpolation() );
   CHECK( 0 == data1.numberDiscretePhotonLines() );
   CHECK( 3 == data1.numberOutgoingEnergies() );
 
   CHECK( 3 == data1.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data1.outgoingEnergies().front() ) );
-  CHECK( 1.84 == Approx( data1.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data1.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.84, WithinRel( data1.outgoingEnergies().back() ) );
 
   CHECK( 3 == data1.pdf().size() );
-  CHECK( 2.364290E-01 == Approx( data1.pdf().front() ) );
-  CHECK( 0. == Approx( data1.pdf().back() ) );
+  CHECK_THAT( 2.364290E-01, WithinRel( data1.pdf().front() ) );
+  CHECK_THAT( 0., WithinRel( data1.pdf().back() ) );
 
   CHECK( 3 == data1.cdf().size() );
-  CHECK( 0. == Approx( data1.cdf().front() ) );
-  CHECK( 1. == Approx( data1.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data1.cdf().back() ) );
 
   auto data2 = chunk.distribution(2);
-  CHECK( 20. == Approx( data2.energyOrCosine() ) );
+  CHECK_THAT( 20., WithinRel( data2.energyOrCosine() ) );
   CHECK( 2 == data2.interpolation() );
   CHECK( 0 == data2.numberDiscretePhotonLines() );
   CHECK( 2 == data2.numberOutgoingEnergies() );
 
   CHECK( 2 == data2.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data2.outgoingEnergies().front() ) );
-  CHECK( 1.84 == Approx( data2.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data2.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.84, WithinRel( data2.outgoingEnergies().back() ) );
 
   CHECK( 2 == data2.pdf().size() );
-  CHECK( 0.5 == Approx( data2.pdf().front() ) );
-  CHECK( 0.5 == Approx( data2.pdf().back() ) );
+  CHECK_THAT( 0.5, WithinRel( data2.pdf().front() ) );
+  CHECK_THAT( 0.5, WithinRel( data2.pdf().back() ) );
 
   CHECK( 2 == data2.cdf().size() );
-  CHECK( 0. == Approx( data2.cdf().front() ) );
-  CHECK( 1. == Approx( data2.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data2.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data2.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/ParameterData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/ParameterData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.ParameterData.test ParameterData.test.cpp )
-target_compile_options( ACEtk.continuous.ParameterData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.ParameterData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.ParameterData COMMAND ACEtk.continuous.ParameterData.test )
+add_cpp_test( continuous.ParameterData ParameterData.test.cpp )

--- a/src/ACEtk/continuous/ParameterData/test/ParameterData.test.cpp
+++ b/src/ACEtk/continuous/ParameterData/test/ParameterData.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/ParameterData.hpp"
 
 // other includes
@@ -40,7 +43,7 @@ SCENARIO( "ParameterData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "ParameterData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,12 +98,12 @@ void verifyChunk( const ParameterData& chunk ) {
   CHECK( 3 == chunk.numberEnergyPoints() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1. == Approx( chunk.energies()[0] ) );
-  CHECK( 3. == Approx( chunk.energies()[1] ) );
-  CHECK( 5. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 5., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.values().size() );
-  CHECK( 2. == Approx( chunk.values()[0] ) );
-  CHECK( 4. == Approx( chunk.values()[1] ) );
-  CHECK( 6. == Approx( chunk.values()[2] ) );
+  CHECK_THAT( 2., WithinRel( chunk.values()[0] ) );
+  CHECK_THAT( 4., WithinRel( chunk.values()[1] ) );
+  CHECK_THAT( 6., WithinRel( chunk.values()[2] ) );
 }

--- a/src/ACEtk/continuous/PhotonProductionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/PhotonProductionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.PhotonProductionBlock.test PhotonProductionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.PhotonProductionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.PhotonProductionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.PhotonProductionBlock COMMAND ACEtk.continuous.PhotonProductionBlock.test )
+add_cpp_test( continuous.PhotonProductionBlock PhotonProductionBlock.test.cpp )

--- a/src/ACEtk/continuous/PhotonProductionBlock/test/PhotonProductionBlock.test.cpp
+++ b/src/ACEtk/continuous/PhotonProductionBlock/test/PhotonProductionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/PhotonProductionBlock.hpp"
 
 // other includes
@@ -63,7 +66,7 @@ SCENARIO( "PhotonProductionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -83,7 +86,7 @@ SCENARIO( "PhotonProductionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -135,6 +138,6 @@ void verifyChunk( const PhotonProductionBlock& chunk ) {
   CHECK( 99 == chunk.numberEnergyPoints() );
   CHECK( 99 == chunk.totalProduction().size() );
 
-  CHECK( 1.17771501000E+03 == Approx( chunk.totalProduction().front() ) );
-  CHECK( 4.82773424000E-01 == Approx( chunk.totalProduction().back() ) );
+  CHECK_THAT( 1.17771501000E+03, WithinRel( chunk.totalProduction().front() ) );
+  CHECK_THAT( 4.82773424000E-01, WithinRel( chunk.totalProduction().back() ) );
 }

--- a/src/ACEtk/continuous/PhotonProductionCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/PhotonProductionCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.PhotonProductionCrossSectionBlock.test PhotonProductionCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.PhotonProductionCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.PhotonProductionCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.PhotonProductionCrossSectionBlock COMMAND ACEtk.continuous.PhotonProductionCrossSectionBlock.test )
+add_cpp_test( continuous.PhotonProductionCrossSectionBlock PhotonProductionCrossSectionBlock.test.cpp )

--- a/src/ACEtk/continuous/PhotonProductionCrossSectionBlock/test/PhotonProductionCrossSectionBlock.test.cpp
+++ b/src/ACEtk/continuous/PhotonProductionCrossSectionBlock/test/PhotonProductionCrossSectionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/PhotonProductionCrossSectionBlock.hpp"
 
 // other includes
@@ -74,7 +77,7 @@ SCENARIO( "PhotonProductionCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,7 +98,7 @@ SCENARIO( "PhotonProductionCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -165,8 +168,8 @@ void verifyChunk( const PhotonProductionCrossSectionBlock& chunk ) {
   CHECK( 1 == xs1.energyIndex() );
   CHECK( 99 == xs1.numberValues() );
   CHECK( 99 == xs1.crossSections().size() );
-  CHECK( 17.17401 == Approx( xs1.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( xs1.crossSections().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( xs1.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( xs1.crossSections().back() ) );
 
   auto xs2 = std::get< TabulatedSecondaryParticleMultiplicity >( chunk.crossSectionData(2) );
   CHECK( 12 == xs2.MFTYPE() );
@@ -188,11 +191,11 @@ void verifyChunk( const PhotonProductionCrossSectionBlock& chunk ) {
   CHECK( 7 == xs2.NE() );
   CHECK( 7 == xs2.numberValues() );
   CHECK( 7 == xs2.energies().size() );
-  CHECK( 0.7742381 == Approx( xs2.energies().front() ) );
-  CHECK( 1. == Approx( xs2.energies()[3] ) );
-  CHECK( 20. == Approx( xs2.energies().back() ) );
+  CHECK_THAT( 0.7742381, WithinRel( xs2.energies().front() ) );
+  CHECK_THAT( 1., WithinRel( xs2.energies()[3] ) );
+  CHECK_THAT( 20., WithinRel( xs2.energies().back() ) );
   CHECK( 7 == xs2.multiplicities().size() );
-  CHECK( 0. == Approx( xs2.multiplicities().front() ) );
-  CHECK( 0.119 == Approx( xs2.multiplicities()[3] ) );
-  CHECK( 0. == Approx( xs2.multiplicities().back() ) );
+  CHECK_THAT( 0., WithinRel( xs2.multiplicities().front() ) );
+  CHECK_THAT( 0.119, WithinRel( xs2.multiplicities()[3] ) );
+  CHECK_THAT( 0., WithinRel( xs2.multiplicities().back() ) );
 }

--- a/src/ACEtk/continuous/PhotonProductionCrossSectionData/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/PhotonProductionCrossSectionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.PhotonProductionCrossSectionData.test PhotonProductionCrossSectionData.test.cpp )
-target_compile_options( ACEtk.continuous.PhotonProductionCrossSectionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.PhotonProductionCrossSectionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.PhotonProductionCrossSectionData COMMAND ACEtk.continuous.PhotonProductionCrossSectionData.test )
+add_cpp_test( continuous.PhotonProductionCrossSectionData PhotonProductionCrossSectionData.test.cpp )

--- a/src/ACEtk/continuous/PhotonProductionCrossSectionData/test/PhotonProductionCrossSectionData.test.cpp
+++ b/src/ACEtk/continuous/PhotonProductionCrossSectionData/test/PhotonProductionCrossSectionData.test.cpp
@@ -1,14 +1,16 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/PhotonProductionCrossSectionData.hpp"
 
 // other includes
 
 // convenience typedefs
 using namespace njoy::ACEtk;
-using PhotonProductionCrossSectionData =
-              continuous::PhotonProductionCrossSectionData;
+using PhotonProductionCrossSectionData = continuous::PhotonProductionCrossSectionData;
 
 std::vector< double > chunk();
 void verifyChunk( const PhotonProductionCrossSectionData& );
@@ -64,7 +66,7 @@ SCENARIO( "PhotonProductionCrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -84,7 +86,7 @@ SCENARIO( "PhotonProductionCrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -135,6 +137,6 @@ void verifyChunk( const PhotonProductionCrossSectionData& chunk ) {
   CHECK( 99 == chunk.numberValues() );
 
   CHECK( 99 == chunk.crossSections().size() );
-  CHECK( 17.17401 == Approx( chunk.crossSections().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( chunk.crossSections().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( chunk.crossSections().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( chunk.crossSections().back() ) );
 }

--- a/src/ACEtk/continuous/PrincipalCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/PrincipalCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.PrincipalCrossSectionBlock.test PrincipalCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.PrincipalCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.PrincipalCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.PrincipalCrossSectionBlock COMMAND ACEtk.continuous.PrincipalCrossSectionBlock.test )
+add_cpp_test( continuous.PrincipalCrossSectionBlock PrincipalCrossSectionBlock.test.cpp )

--- a/src/ACEtk/continuous/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/continuous/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/PrincipalCrossSectionBlock.hpp"
 
 // other includes
@@ -180,7 +183,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -200,7 +203,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -354,14 +357,14 @@ void verifyChunk( const PrincipalCrossSectionBlock& chunk ) {
   CHECK( 99 == chunk.elastic().size() );
   CHECK( 99 == chunk.heating().size() );
 
-  CHECK( 1.00000000000E-11 == Approx( chunk.energies().front() ) );
-  CHECK( 2.00000000000E+01 == Approx( chunk.energies().back() ) );
-  CHECK( 1.17771501000E+03 == Approx( chunk.total().front() ) );
-  CHECK( 4.82773424000E-01 == Approx( chunk.total().back() ) );
-  CHECK( 1.71740100000E+01 == Approx( chunk.disappearance().front() ) );
-  CHECK( 2.72235400000E-05 == Approx( chunk.disappearance().back() ) );
-  CHECK( 1.16054100000E+03 == Approx( chunk.elastic().front() ) );
-  CHECK( 4.82746200000E-01 == Approx( chunk.elastic().back() ) );
-  CHECK( 1.91876400000E-05 == Approx( chunk.heating().front() ) );
-  CHECK( 1.01608500000E+01 == Approx( chunk.heating().back() ) );
+  CHECK_THAT( 1.00000000000E-11, WithinRel( chunk.energies().front() ) );
+  CHECK_THAT( 2.00000000000E+01, WithinRel( chunk.energies().back() ) );
+  CHECK_THAT( 1.17771501000E+03, WithinRel( chunk.total().front() ) );
+  CHECK_THAT( 4.82773424000E-01, WithinRel( chunk.total().back() ) );
+  CHECK_THAT( 1.71740100000E+01, WithinRel( chunk.disappearance().front() ) );
+  CHECK_THAT( 2.72235400000E-05, WithinRel( chunk.disappearance().back() ) );
+  CHECK_THAT( 1.16054100000E+03, WithinRel( chunk.elastic().front() ) );
+  CHECK_THAT( 4.82746200000E-01, WithinRel( chunk.elastic().back() ) );
+  CHECK_THAT( 1.91876400000E-05, WithinRel( chunk.heating().front() ) );
+  CHECK_THAT( 1.01608500000E+01, WithinRel( chunk.heating().back() ) );
 }

--- a/src/ACEtk/continuous/ProbabilityTable/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/ProbabilityTable/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.ProbabilityTable.test ProbabilityTable.test.cpp )
-target_compile_options( ACEtk.continuous.ProbabilityTable.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.ProbabilityTable.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.ProbabilityTable COMMAND ACEtk.continuous.ProbabilityTable.test )
+add_cpp_test( continuous.ProbabilityTable ProbabilityTable.test.cpp )

--- a/src/ACEtk/continuous/ProbabilityTable/test/ProbabilityTable.test.cpp
+++ b/src/ACEtk/continuous/ProbabilityTable/test/ProbabilityTable.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/ProbabilityTable.hpp"
 
 // other includes
@@ -89,7 +92,7 @@ SCENARIO( "ProbabilityTable" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -109,7 +112,7 @@ SCENARIO( "ProbabilityTable" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -156,7 +159,7 @@ void verifyChunk( const ProbabilityTable& chunk ) {
 
   CHECK( 96 == chunk.XSS().size() );
 
-  CHECK( 2.250001e-3 == Approx( chunk.incidentEnergy() ) );
+  CHECK_THAT( 2.250001e-3, WithinRel( chunk.incidentEnergy() ) );
 
   CHECK( 16 == chunk.numberBins() );
   CHECK( 16 == chunk.cumulativeProbabilities().size() );
@@ -166,16 +169,16 @@ void verifyChunk( const ProbabilityTable& chunk ) {
   CHECK( 16 == chunk.capture().size() );
   CHECK( 16 == chunk.heating().size() );
 
-  CHECK( 2.97187500000E-03 == Approx( chunk.cumulativeProbabilities().front() ) );
-  CHECK( 1. == Approx( chunk.cumulativeProbabilities().back() ) );
-  CHECK( 6.20303500000E-01 == Approx( chunk.total().front() ) );
-  CHECK( 2.08166900000E+00 == Approx( chunk.total().back() ) );
-  CHECK( 8.88269000000E-01 == Approx( chunk.elastic().front() ) );
-  CHECK( 1.25902700000E+00 == Approx( chunk.elastic().back() ) );
-  CHECK( 2.06017200000E-01 == Approx( chunk.fission().front() ) );
-  CHECK( 3.24694300000E+00 == Approx( chunk.fission().back() ) );
-  CHECK( 1.79948200000E-01 == Approx( chunk.capture().front() ) );
-  CHECK( 3.73081700000E+00 == Approx( chunk.capture().back() ) );
-  CHECK( 1. == Approx( chunk.heating().front() ) );
-  CHECK( 1. == Approx( chunk.heating().back() ) );
+  CHECK_THAT( 2.97187500000E-03, WithinRel( chunk.cumulativeProbabilities().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cumulativeProbabilities().back() ) );
+  CHECK_THAT( 6.20303500000E-01, WithinRel( chunk.total().front() ) );
+  CHECK_THAT( 2.08166900000E+00, WithinRel( chunk.total().back() ) );
+  CHECK_THAT( 8.88269000000E-01, WithinRel( chunk.elastic().front() ) );
+  CHECK_THAT( 1.25902700000E+00, WithinRel( chunk.elastic().back() ) );
+  CHECK_THAT( 2.06017200000E-01, WithinRel( chunk.fission().front() ) );
+  CHECK_THAT( 3.24694300000E+00, WithinRel( chunk.fission().back() ) );
+  CHECK_THAT( 1.79948200000E-01, WithinRel( chunk.capture().front() ) );
+  CHECK_THAT( 3.73081700000E+00, WithinRel( chunk.capture().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.heating().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.heating().back() ) );
 }

--- a/src/ACEtk/continuous/ProbabilityTableBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/ProbabilityTableBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.ProbabilityTableBlock.test ProbabilityTableBlock.test.cpp )
-target_compile_options( ACEtk.continuous.ProbabilityTableBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.ProbabilityTableBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.ProbabilityTableBlock COMMAND ACEtk.continuous.ProbabilityTableBlock.test )
+add_cpp_test( continuous.ProbabilityTableBlock ProbabilityTableBlock.test.cpp )

--- a/src/ACEtk/continuous/ProbabilityTableBlock/test/ProbabilityTableBlock.test.cpp
+++ b/src/ACEtk/continuous/ProbabilityTableBlock/test/ProbabilityTableBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/ProbabilityTableBlock.hpp"
 
 // other includes
@@ -47,7 +50,7 @@ SCENARIO( "ProbabilityTableBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -67,7 +70,7 @@ SCENARIO( "ProbabilityTableBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -103,11 +106,11 @@ void verifyChunk( const ProbabilityTableBlock& chunk ) {
   CHECK( 1 == chunk.type() );
 
   CHECK( 2 == chunk.energies().size() );
-  CHECK( 1e-3 == Approx( chunk.energies()[0] ) );
-  CHECK( 1e+3 == Approx( chunk.energies()[1] ) );
+  CHECK_THAT( 1e-3, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1e+3, WithinRel( chunk.energies()[1] ) );
 
   auto table1 = chunk.probabilityTable(1);
-  CHECK( 1e-3 == Approx( table1.incidentEnergy() ) );
+  CHECK_THAT( 1e-3, WithinRel( table1.incidentEnergy() ) );
 
   CHECK( 2 == table1.numberBins() );
   CHECK( 2 == table1.cumulativeProbabilities().size() );
@@ -117,21 +120,21 @@ void verifyChunk( const ProbabilityTableBlock& chunk ) {
   CHECK( 2 == table1.capture().size() );
   CHECK( 2 == table1.heating().size() );
 
-  CHECK( 0.5 == Approx( table1.cumulativeProbabilities().front() ) );
-  CHECK( 1.0 == Approx( table1.cumulativeProbabilities().back() ) );
-  CHECK( 1. == Approx( table1.total().front() ) );
-  CHECK( 2. == Approx( table1.total().back() ) );
-  CHECK( 3. == Approx( table1.elastic().front() ) );
-  CHECK( 4. == Approx( table1.elastic().back() ) );
-  CHECK( 5. == Approx( table1.fission().front() ) );
-  CHECK( 6. == Approx( table1.fission().back() ) );
-  CHECK( 7. == Approx( table1.capture().front() ) );
-  CHECK( 8. == Approx( table1.capture().back() ) );
-  CHECK( 9. == Approx( table1.heating().front() ) );
-  CHECK( 10. == Approx( table1.heating().back() ) );
+  CHECK_THAT( 0.5, WithinRel( table1.cumulativeProbabilities().front() ) );
+  CHECK_THAT( 1.0, WithinRel( table1.cumulativeProbabilities().back() ) );
+  CHECK_THAT( 1., WithinRel( table1.total().front() ) );
+  CHECK_THAT( 2., WithinRel( table1.total().back() ) );
+  CHECK_THAT( 3., WithinRel( table1.elastic().front() ) );
+  CHECK_THAT( 4., WithinRel( table1.elastic().back() ) );
+  CHECK_THAT( 5., WithinRel( table1.fission().front() ) );
+  CHECK_THAT( 6., WithinRel( table1.fission().back() ) );
+  CHECK_THAT( 7., WithinRel( table1.capture().front() ) );
+  CHECK_THAT( 8., WithinRel( table1.capture().back() ) );
+  CHECK_THAT( 9., WithinRel( table1.heating().front() ) );
+  CHECK_THAT( 10., WithinRel( table1.heating().back() ) );
 
   auto table2 = chunk.probabilityTable(2);
-  CHECK( 1e+3 == Approx( table2.incidentEnergy() ) );
+  CHECK_THAT( 1e+3, WithinRel( table2.incidentEnergy() ) );
 
   CHECK( 2 == table2.numberBins() );
   CHECK( 2 == table2.cumulativeProbabilities().size() );
@@ -141,16 +144,16 @@ void verifyChunk( const ProbabilityTableBlock& chunk ) {
   CHECK( 2 == table2.capture().size() );
   CHECK( 2 == table2.heating().size() );
 
-  CHECK( 0.25 == Approx( table2.cumulativeProbabilities().front() ) );
-  CHECK( 1.0 == Approx( table2.cumulativeProbabilities().back() ) );
-  CHECK( 11. == Approx( table2.total().front() ) );
-  CHECK( 12. == Approx( table2.total().back() ) );
-  CHECK( 13. == Approx( table2.elastic().front() ) );
-  CHECK( 14. == Approx( table2.elastic().back() ) );
-  CHECK( 15. == Approx( table2.fission().front() ) );
-  CHECK( 16. == Approx( table2.fission().back() ) );
-  CHECK( 17. == Approx( table2.capture().front() ) );
-  CHECK( 18. == Approx( table2.capture().back() ) );
-  CHECK( 19. == Approx( table2.heating().front() ) );
-  CHECK( 20. == Approx( table2.heating().back() ) );
+  CHECK_THAT( 0.25, WithinRel( table2.cumulativeProbabilities().front() ) );
+  CHECK_THAT( 1.0, WithinRel( table2.cumulativeProbabilities().back() ) );
+  CHECK_THAT( 11., WithinRel( table2.total().front() ) );
+  CHECK_THAT( 12., WithinRel( table2.total().back() ) );
+  CHECK_THAT( 13., WithinRel( table2.elastic().front() ) );
+  CHECK_THAT( 14., WithinRel( table2.elastic().back() ) );
+  CHECK_THAT( 15., WithinRel( table2.fission().front() ) );
+  CHECK_THAT( 16., WithinRel( table2.fission().back() ) );
+  CHECK_THAT( 17., WithinRel( table2.capture().front() ) );
+  CHECK_THAT( 18., WithinRel( table2.capture().back() ) );
+  CHECK_THAT( 19., WithinRel( table2.heating().front() ) );
+  CHECK_THAT( 20., WithinRel( table2.heating().back() ) );
 }

--- a/src/ACEtk/continuous/ReactionNumberBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/ReactionNumberBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.ReactionNumberBlock.test ReactionNumberBlock.test.cpp )
-target_compile_options( ACEtk.continuous.ReactionNumberBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.ReactionNumberBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.ReactionNumberBlock COMMAND ACEtk.continuous.ReactionNumberBlock.test )
+add_cpp_test( continuous.ReactionNumberBlock ReactionNumberBlock.test.cpp )

--- a/src/ACEtk/continuous/ReactionNumberBlock/test/ReactionNumberBlock.test.cpp
+++ b/src/ACEtk/continuous/ReactionNumberBlock/test/ReactionNumberBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/ReactionNumberBlock.hpp"
 
 // other includes
@@ -35,7 +38,7 @@ SCENARIO( "ReactionNumberBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -55,7 +58,7 @@ SCENARIO( "ReactionNumberBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/ReactionQValueBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/ReactionQValueBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.ReactionQValueBlock.test ReactionQValueBlock.test.cpp )
-target_compile_options( ACEtk.continuous.ReactionQValueBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.ReactionQValueBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.ReactionQValueBlock COMMAND ACEtk.continuous.ReactionQValueBlock.test )
+add_cpp_test( continuous.ReactionQValueBlock ReactionQValueBlock.test.cpp )

--- a/src/ACEtk/continuous/ReactionQValueBlock/test/ReactionQValueBlock.test.cpp
+++ b/src/ACEtk/continuous/ReactionQValueBlock/test/ReactionQValueBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/ReactionQValueBlock.hpp"
 
 // other includes
@@ -35,7 +38,7 @@ SCENARIO( "ReactionQValueBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -55,7 +58,7 @@ SCENARIO( "ReactionQValueBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -76,12 +79,12 @@ void verifyChunk( const ReactionQValueBlock& chunk ) {
   CHECK( 3 == chunk.NTR() );
   CHECK( 3 == chunk.numberReactions() );
 
-  CHECK( 2.224631 == Approx( chunk.QValue(1) ) );
-  CHECK( 0 == Approx( chunk.QValue(2) ) );
-  CHECK( 0 == Approx( chunk.QValue(3) ) );
+  CHECK_THAT( 2.224631, WithinRel( chunk.QValue(1) ) );
+  CHECK_THAT( 0, WithinRel( chunk.QValue(2) ) );
+  CHECK_THAT( 0, WithinRel( chunk.QValue(3) ) );
 
   CHECK( 3 == chunk.QValues().size() );
-  CHECK( 2.224631 == Approx( chunk.QValues()[0] ) );
-  CHECK( 0 == Approx( chunk.QValues()[1] ) );
-  CHECK( 0 == Approx( chunk.QValues()[2] ) );
+  CHECK_THAT( 2.224631, WithinRel( chunk.QValues()[0] ) );
+  CHECK_THAT( 0, WithinRel( chunk.QValues()[1] ) );
+  CHECK_THAT( 0, WithinRel( chunk.QValues()[2] ) );
 }

--- a/src/ACEtk/continuous/SecondaryParticleAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleAngularDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleAngularDistributionBlock.test SecondaryParticleAngularDistributionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleAngularDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleAngularDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleAngularDistributionBlock COMMAND ACEtk.continuous.SecondaryParticleAngularDistributionBlock.test )
+add_cpp_test( continuous.SecondaryParticleAngularDistributionBlock SecondaryParticleAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleAngularDistributionBlock/test/SecondaryParticleAngularDistributionBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleAngularDistributionBlock/test/SecondaryParticleAngularDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleAngularDistributionBlock.hpp"
 
 // other includes
@@ -56,7 +59,7 @@ SCENARIO( "SecondaryParticleAngularDistributionBlock" ) {
          auto xss_chunk = chunk.XSS();
          for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-           CHECK( xss[i] == Approx( xss_chunk[i] ) );
+           CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
          }
        } // THEN
      } // WHEN
@@ -76,7 +79,7 @@ SCENARIO( "SecondaryParticleAngularDistributionBlock" ) {
          auto xss_chunk = chunk.XSS();
          for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-           CHECK( xss[i] == Approx( xss_chunk[i] ) );
+           CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
          }
        } // THEN
      } // WHEN
@@ -146,10 +149,10 @@ void verifyChunk( const SecondaryParticleAngularDistributionBlock& chunk ) {
   CHECK( 2 == data1.NE() );
   CHECK( 2 == data1.numberIncidentEnergies() );
   CHECK( 2 == data1.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( data1.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( data1.incidentEnergies()[1] ) );
-  CHECK( 1e-11 == Approx( data1.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( data1.incidentEnergy(2) ) );
+  CHECK_THAT( 1e-11, WithinRel( data1.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( data1.incidentEnergies()[1] ) );
+  CHECK_THAT( 1e-11, WithinRel( data1.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( data1.incidentEnergy(2) ) );
   CHECK( -6 == data1.LOCC(1) );
   CHECK( -14 == data1.LOCC(2) );
   CHECK( -6 == data1.distributionLocator(1) );
@@ -165,12 +168,12 @@ void verifyChunk( const SecondaryParticleAngularDistributionBlock& chunk ) {
   CHECK( 3 == data4.NE() );
   CHECK( 3 == data4.numberIncidentEnergies() );
   CHECK( 3 == data4.incidentEnergies().size() );
-  CHECK( 1e-11 == Approx( data4.incidentEnergies()[0] ) );
-  CHECK( 1. == Approx( data4.incidentEnergies()[1] ) );
-  CHECK( 20. == Approx( data4.incidentEnergies()[2] ) );
-  CHECK( 1e-11 == Approx( data4.incidentEnergy(1) ) );
-  CHECK( 1. == Approx( data4.incidentEnergy(2) ) );
-  CHECK( 20. == Approx( data4.incidentEnergy(3) ) );
+  CHECK_THAT( 1e-11, WithinRel( data4.incidentEnergies()[0] ) );
+  CHECK_THAT( 1., WithinRel( data4.incidentEnergies()[1] ) );
+  CHECK_THAT( 20., WithinRel( data4.incidentEnergies()[2] ) );
+  CHECK_THAT( 1e-11, WithinRel( data4.incidentEnergy(1) ) );
+  CHECK_THAT( 1., WithinRel( data4.incidentEnergy(2) ) );
+  CHECK_THAT( 20., WithinRel( data4.incidentEnergy(3) ) );
   CHECK( -32 == data4.LOCC(1) );
   CHECK( 0 == data4.LOCC(2) );
   CHECK( -43 == data4.LOCC(3) );

--- a/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleEnergyDistributionBlock.test SecondaryParticleEnergyDistributionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleEnergyDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleEnergyDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleEnergyDistributionBlock COMMAND ACEtk.continuous.SecondaryParticleEnergyDistributionBlock.test )
+add_cpp_test( continuous.SecondaryParticleEnergyDistributionBlock SecondaryParticleEnergyDistributionBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/test/SecondaryParticleEnergyDistributionBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/test/SecondaryParticleEnergyDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleEnergyDistributionBlock.hpp"
 
 // other includes
@@ -59,7 +62,7 @@ SCENARIO( "SecondaryParticleEnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -82,7 +85,7 @@ SCENARIO( "SecondaryParticleEnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -140,10 +143,10 @@ void verifyChunk( const SecondaryParticleEnergyDistributionBlock& chunk ) {
   auto data1 = std::get< LevelScatteringDistribution >( chunk.energyDistributionData(1) );
   CHECK( EnergyDistributionType::LevelScattering == data1.LAW() );
   CHECK( EnergyDistributionType::LevelScattering == data1.type() );
-  CHECK( 2.249999e-3 == Approx( data1.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( data1.maximumIncidentEnergy() ) );
-  CHECK( 7.71295800000E-05 == Approx( data1.C1() ) );
-  CHECK( .9914722 == Approx( data1.C2() ) );
+  CHECK_THAT( 2.249999e-3, WithinRel( data1.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data1.maximumIncidentEnergy() ) );
+  CHECK_THAT( 7.71295800000E-05, WithinRel( data1.C1() ) );
+  CHECK_THAT( .9914722, WithinRel( data1.C2() ) );
 
   auto data2 = std::get< KalbachMannDistributionData >( chunk.energyDistributionData(2) );
   CHECK( EnergyDistributionType::KalbachMann == data2.LAW() );
@@ -151,12 +154,12 @@ void verifyChunk( const SecondaryParticleEnergyDistributionBlock& chunk ) {
   CHECK( 2 == data2.NE() );
   CHECK( 2 == data2.numberIncidentEnergies() );
   CHECK( 2 == data2.incidentEnergies().size() );
-  CHECK( 1.219437E+01 == Approx( data2.incidentEnergies()[0] ) );
-  CHECK( 20. == Approx( data2.incidentEnergies()[1] ) );
-  CHECK( 1.219437E+01 == Approx( data2.incidentEnergy(1) ) );
-  CHECK( 20. == Approx( data2.incidentEnergy(2) ) );
-  CHECK( 1.219437E+01 == Approx( data2.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( data2.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.incidentEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergies()[1] ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.incidentEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( data2.incidentEnergy(2) ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data2.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data2.maximumIncidentEnergy() ) );
   CHECK( 27 == data2.LOCC(1) );
   CHECK( 39 == data2.LOCC(2) );
   CHECK( 27 == data2.distributionLocator(1) );
@@ -164,45 +167,45 @@ void verifyChunk( const SecondaryParticleEnergyDistributionBlock& chunk ) {
   CHECK( 7 == data2.relativeDistributionLocator(1) );
   CHECK( 19 == data2.relativeDistributionLocator(2) );
   auto data21 = data2.distribution(1);
-  CHECK( 1.219437E+01 == Approx( data21.incidentEnergy() ) );
+  CHECK_THAT( 1.219437E+01, WithinRel( data21.incidentEnergy() ) );
   CHECK( 1 == data21.interpolation() );
   CHECK( 0 == data21.numberDiscretePhotonLines() );
   CHECK( 2 == data21.numberOutgoingEnergies() );
   CHECK( 2 == data21.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data21.outgoingEnergies().front() ) );
-  CHECK( 1.866919E-02 == Approx( data21.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data21.outgoingEnergies().front() ) );
+  CHECK_THAT( 1.866919E-02, WithinRel( data21.outgoingEnergies().back() ) );
   CHECK( 2 == data21.pdf().size() );
-  CHECK( 5.356419E+01 == Approx( data21.pdf().front() ) );
-  CHECK( 0. == Approx( data21.pdf().back() ) );
+  CHECK_THAT( 5.356419E+01, WithinRel( data21.pdf().front() ) );
+  CHECK_THAT( 0., WithinRel( data21.pdf().back() ) );
   CHECK( 2 == data21.cdf().size() );
-  CHECK( 0. == Approx( data21.cdf().front() ) );
-  CHECK( 1. == Approx( data21.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data21.cdf().back() ) );
   CHECK( 2 == data21.precompoundFractionValues().size() );
-  CHECK( 0. == Approx( data21.precompoundFractionValues().front() ) );
-  CHECK( 0. == Approx( data21.precompoundFractionValues().back() ) );
+  CHECK_THAT( 0., WithinRel( data21.precompoundFractionValues().front() ) );
+  CHECK_THAT( 0., WithinRel( data21.precompoundFractionValues().back() ) );
   CHECK( 2 == data21.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data21.angularDistributionSlopeValues().front() ) );
-  CHECK( 2.398743E-01 == Approx( data21.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data21.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 2.398743E-01, WithinRel( data21.angularDistributionSlopeValues().back() ) );
   auto data22 = data2.distribution(2);
-  CHECK( 20. == Approx( data22.incidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( data22.incidentEnergy() ) );
   CHECK( 2 == data22.interpolation() );
   CHECK( 0 == data22.numberDiscretePhotonLines() );
   CHECK( 3 == data22.numberOutgoingEnergies() );
   CHECK( 3 == data22.outgoingEnergies().size() );
-  CHECK( 0.0 == Approx( data22.outgoingEnergies().front() ) );
-  CHECK( 7.592137E+00 == Approx( data22.outgoingEnergies().back() ) );
+  CHECK_THAT( 0.0, WithinRel( data22.outgoingEnergies().front() ) );
+  CHECK_THAT( 7.592137E+00, WithinRel( data22.outgoingEnergies().back() ) );
   CHECK( 3 == data22.pdf().size() );
-  CHECK( 7.738696E-02 == Approx( data22.pdf().front() ) );
-  CHECK( 1.226090E-11 == Approx( data22.pdf().back() ) );
+  CHECK_THAT( 7.738696E-02, WithinRel( data22.pdf().front() ) );
+  CHECK_THAT( 1.226090E-11, WithinRel( data22.pdf().back() ) );
   CHECK( 3 == data22.cdf().size() );
-  CHECK( 0. == Approx( data22.cdf().front() ) );
-  CHECK( 1. == Approx( data22.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data22.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data22.cdf().back() ) );
   CHECK( 3 == data22.precompoundFractionValues().size() );
-  CHECK( 2.491475E-03 == Approx( data22.precompoundFractionValues().front() ) );
-  CHECK( 9.775367E-01 == Approx( data22.precompoundFractionValues().back() ) );
+  CHECK_THAT( 2.491475E-03, WithinRel( data22.precompoundFractionValues().front() ) );
+  CHECK_THAT( 9.775367E-01, WithinRel( data22.precompoundFractionValues().back() ) );
   CHECK( 3 == data22.angularDistributionSlopeValues().size() );
-  CHECK( 2.391154E-01 == Approx( data22.angularDistributionSlopeValues().front() ) );
-  CHECK( 5.592013E-01 == Approx( data22.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 2.391154E-01, WithinRel( data22.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 5.592013E-01, WithinRel( data22.angularDistributionSlopeValues().back() ) );
 
   CHECK( ReferenceFrame::Laboratory == chunk.referenceFrame(1).value() );
   CHECK( ReferenceFrame::CentreOfMass == chunk.referenceFrame(2).value() );

--- a/src/ACEtk/continuous/SecondaryParticleInformationBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleInformationBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleInformationBlock.test SecondaryParticleInformationBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleInformationBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleInformationBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleInformationBlock COMMAND ACEtk.continuous.SecondaryParticleInformationBlock.test )
+add_cpp_test( continuous.SecondaryParticleInformationBlock SecondaryParticleInformationBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleInformationBlock/test/SecondaryParticleInformationBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleInformationBlock/test/SecondaryParticleInformationBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleInformationBlock.hpp"
 
 // other includes
@@ -35,7 +38,7 @@ SCENARIO( "SecondaryParticleInformationBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -55,7 +58,7 @@ SCENARIO( "SecondaryParticleInformationBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/SecondaryParticleLocatorBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleLocatorBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleLocatorBlock.test SecondaryParticleLocatorBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleLocatorBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleLocatorBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleLocatorBlock COMMAND ACEtk.continuous.SecondaryParticleLocatorBlock.test )
+add_cpp_test( continuous.SecondaryParticleLocatorBlock SecondaryParticleLocatorBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleLocatorBlock.hpp"
 
 // other includes
@@ -39,7 +42,7 @@ SCENARIO( "SecondaryParticleLocatorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "SecondaryParticleLocatorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/SecondaryParticleProductionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleProductionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleProductionBlock.test SecondaryParticleProductionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleProductionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleProductionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleProductionBlock COMMAND ACEtk.continuous.SecondaryParticleProductionBlock.test )
+add_cpp_test( continuous.SecondaryParticleProductionBlock SecondaryParticleProductionBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleProductionBlock/test/SecondaryParticleProductionBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleProductionBlock/test/SecondaryParticleProductionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleProductionBlock.hpp"
 
 // other includes
@@ -45,7 +48,7 @@ SCENARIO( "SecondaryParticleProductionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -65,7 +68,7 @@ SCENARIO( "SecondaryParticleProductionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,10 +94,10 @@ void verifyChunk( const SecondaryParticleProductionBlock& chunk ) {
   CHECK( 3 == chunk.numberValues() );
 
   CHECK( 3 == chunk.totalProduction().size() );
-  CHECK( 17.17401 == Approx( chunk.totalProduction().front() ) );
-  CHECK( 272.2354 == Approx( chunk.totalProduction().back() ) );
+  CHECK_THAT( 17.17401, WithinRel( chunk.totalProduction().front() ) );
+  CHECK_THAT( 272.2354, WithinRel( chunk.totalProduction().back() ) );
 
   CHECK( 3 == chunk.heating().size() );
-  CHECK( 3.63894900000E-05 == Approx( chunk.heating().front() ) );
-  CHECK( 3.70168600000E-05 == Approx( chunk.heating().back() ) );
+  CHECK_THAT( 3.63894900000E-05, WithinRel( chunk.heating().front() ) );
+  CHECK_THAT( 3.70168600000E-05, WithinRel( chunk.heating().back() ) );
 }

--- a/src/ACEtk/continuous/SecondaryParticleProductionCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleProductionCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleProductionCrossSectionBlock.test SecondaryParticleProductionCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleProductionCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleProductionCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleProductionCrossSectionBlock COMMAND ACEtk.continuous.SecondaryParticleProductionCrossSectionBlock.test )
+add_cpp_test( continuous.SecondaryParticleProductionCrossSectionBlock SecondaryParticleProductionCrossSectionBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleProductionCrossSectionBlock/test/SecondaryParticleProductionCrossSectionBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleProductionCrossSectionBlock/test/SecondaryParticleProductionCrossSectionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleProductionCrossSectionBlock.hpp"
 
 // other includes
@@ -49,7 +52,7 @@ SCENARIO( "SecondaryParticleProductionCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -70,7 +73,7 @@ SCENARIO( "SecondaryParticleProductionCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -126,13 +129,13 @@ void verifyChunk( const SecondaryParticleProductionCrossSectionBlock& chunk ) {
   CHECK( 7 == xs1.NE() );
   CHECK( 7 == xs1.numberValues() );
   CHECK( 7 == xs1.energies().size() );
-  CHECK( 0.7742381 == Approx( xs1.energies().front() ) );
-  CHECK( 1. == Approx( xs1.energies()[3] ) );
-  CHECK( 20. == Approx( xs1.energies().back() ) );
+  CHECK_THAT( 0.7742381, WithinRel( xs1.energies().front() ) );
+  CHECK_THAT( 1., WithinRel( xs1.energies()[3] ) );
+  CHECK_THAT( 20., WithinRel( xs1.energies().back() ) );
   CHECK( 7 == xs1.multiplicities().size() );
-  CHECK( 0. == Approx( xs1.multiplicities().front() ) );
-  CHECK( 0.119 == Approx( xs1.multiplicities()[3] ) );
-  CHECK( 0. == Approx( xs1.multiplicities().back() ) );
+  CHECK_THAT( 0., WithinRel( xs1.multiplicities().front() ) );
+  CHECK_THAT( 0.119, WithinRel( xs1.multiplicities()[3] ) );
+  CHECK_THAT( 0., WithinRel( xs1.multiplicities().back() ) );
 
   auto xs2 = chunk.crossSectionData(2);
   CHECK( 12 == xs2.MFTYPE() );
@@ -154,9 +157,9 @@ void verifyChunk( const SecondaryParticleProductionCrossSectionBlock& chunk ) {
   CHECK( 2 == xs2.NE() );
   CHECK( 2 == xs2.numberValues() );
   CHECK( 2 == xs2.energies().size() );
-  CHECK( 1e-5 == Approx( xs2.energies().front() ) );
-  CHECK( 20. == Approx( xs2.energies().back() ) );
+  CHECK_THAT( 1e-5, WithinRel( xs2.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( xs2.energies().back() ) );
   CHECK( 2 == xs2.multiplicities().size() );
-  CHECK( 1. == Approx( xs2.multiplicities().front() ) );
-  CHECK( 1. == Approx( xs2.multiplicities().back() ) );
+  CHECK_THAT( 1., WithinRel( xs2.multiplicities().front() ) );
+  CHECK_THAT( 1., WithinRel( xs2.multiplicities().back() ) );
 }

--- a/src/ACEtk/continuous/SecondaryParticleTypeBlock/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SecondaryParticleTypeBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SecondaryParticleTypeBlock.test SecondaryParticleTypeBlock.test.cpp )
-target_compile_options( ACEtk.continuous.SecondaryParticleTypeBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SecondaryParticleTypeBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SecondaryParticleTypeBlock COMMAND ACEtk.continuous.SecondaryParticleTypeBlock.test )
+add_cpp_test( continuous.SecondaryParticleTypeBlock SecondaryParticleTypeBlock.test.cpp )

--- a/src/ACEtk/continuous/SecondaryParticleTypeBlock/test/SecondaryParticleTypeBlock.test.cpp
+++ b/src/ACEtk/continuous/SecondaryParticleTypeBlock/test/SecondaryParticleTypeBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SecondaryParticleTypeBlock.hpp"
 
 // other includes
@@ -35,7 +38,7 @@ SCENARIO( "SecondaryParticleTypeBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -55,7 +58,7 @@ SCENARIO( "SecondaryParticleTypeBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/continuous/SimpleMaxwellianFissionSpectrum/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/SimpleMaxwellianFissionSpectrum/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.SimpleMaxwellianFissionSpectrum.test SimpleMaxwellianFissionSpectrum.test.cpp )
-target_compile_options( ACEtk.continuous.SimpleMaxwellianFissionSpectrum.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.SimpleMaxwellianFissionSpectrum.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.SimpleMaxwellianFissionSpectrum COMMAND ACEtk.continuous.SimpleMaxwellianFissionSpectrum.test )
+add_cpp_test( continuous.SimpleMaxwellianFissionSpectrum SimpleMaxwellianFissionSpectrum.test.cpp )

--- a/src/ACEtk/continuous/SimpleMaxwellianFissionSpectrum/test/SimpleMaxwellianFissionSpectrum.test.cpp
+++ b/src/ACEtk/continuous/SimpleMaxwellianFissionSpectrum/test/SimpleMaxwellianFissionSpectrum.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/SimpleMaxwellianFissionSpectrum.hpp"
 
 // other includes
@@ -39,7 +42,7 @@ SCENARIO( "SimpleMaxwellianFissionSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -58,7 +61,7 @@ SCENARIO( "SimpleMaxwellianFissionSpectrum" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -99,19 +102,19 @@ void verifyChunk( const SimpleMaxwellianFissionSpectrum& chunk ) {
   CHECK( 4 == chunk.numberEnergyPoints() );
 
   CHECK( 4 == chunk.energies().size() );
-  CHECK( 1e-05 == Approx( chunk.energies()[0] ) );
-  CHECK( 1. == Approx( chunk.energies()[1] ) );
-  CHECK( 10. == Approx( chunk.energies()[2] ) );
-  CHECK( 20. == Approx( chunk.energies()[3] ) );
+  CHECK_THAT( 1e-05, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 10., WithinRel( chunk.energies()[2] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[3] ) );
 
   CHECK( 4 == chunk.temperatures().size() );
-  CHECK( 1. == Approx( chunk.temperatures()[0] ) );
-  CHECK( 2. == Approx( chunk.temperatures()[1] ) );
-  CHECK( 3. == Approx( chunk.temperatures()[2] ) );
-  CHECK( 4. == Approx( chunk.temperatures()[3] ) );
+  CHECK_THAT( 1., WithinRel( chunk.temperatures()[0] ) );
+  CHECK_THAT( 2., WithinRel( chunk.temperatures()[1] ) );
+  CHECK_THAT( 3., WithinRel( chunk.temperatures()[2] ) );
+  CHECK_THAT( 4., WithinRel( chunk.temperatures()[3] ) );
 
-  CHECK( 1e-5 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
   CHECK( 1.5e+6 == chunk.U() );
   CHECK( 1.5e+6 == chunk.restrictionEnergy() );

--- a/src/ACEtk/continuous/TabulatedAngleEnergyDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedAngleEnergyDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedAngleEnergyDistribution.test TabulatedAngleEnergyDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedAngleEnergyDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedAngleEnergyDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedAngleEnergyDistribution COMMAND ACEtk.continuous.TabulatedAngleEnergyDistribution.test )
+add_cpp_test( continuous.TabulatedAngleEnergyDistribution TabulatedAngleEnergyDistribution.test.cpp )

--- a/src/ACEtk/continuous/TabulatedAngleEnergyDistribution/test/TabulatedAngleEnergyDistribution.test.cpp
+++ b/src/ACEtk/continuous/TabulatedAngleEnergyDistribution/test/TabulatedAngleEnergyDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedAngleEnergyDistribution.hpp"
 
 // other includes
@@ -47,7 +50,7 @@ SCENARIO( "TabulatedAngleEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -67,7 +70,7 @@ SCENARIO( "TabulatedAngleEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,7 +94,7 @@ void verifyChunk( const TabulatedAngleEnergyDistribution& chunk ) {
   CHECK( 25 == chunk.length() );
   CHECK( "TabulatedAngleEnergyDistribution" == chunk.name() );
 
-  CHECK( 1.1 == Approx( chunk.incidentEnergy() ) );
+  CHECK_THAT( 1.1, WithinRel( chunk.incidentEnergy() ) );
 
   CHECK( 2 == chunk.interpolation() );
 
@@ -100,11 +103,11 @@ void verifyChunk( const TabulatedAngleEnergyDistribution& chunk ) {
   CHECK( 2 == chunk.distributions().size() );
 
   CHECK( 2 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines()[0] ) );
-  CHECK( 1. == Approx( chunk.cosines()[1] ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.cosines()[1] ) );
 
-  CHECK( -1. == Approx( chunk.cosine(1) ) );
-  CHECK( 1. == Approx( chunk.cosine(2) ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosine(1) ) );
+  CHECK_THAT( 1., WithinRel( chunk.cosine(2) ) );
 
   CHECK( 27 == chunk.LOCC(1) );
   CHECK( 38 == chunk.LOCC(2) );
@@ -115,36 +118,36 @@ void verifyChunk( const TabulatedAngleEnergyDistribution& chunk ) {
   CHECK( 18 == chunk.relativeDistributionLocator(2) );
 
   auto data1 = chunk.distribution(1);
-  CHECK( -1. == Approx( data1.energyOrCosine() ) );
+  CHECK_THAT( -1., WithinRel( data1.energyOrCosine() ) );
   CHECK( 2 == data1.interpolation() );
   CHECK( 3 == data1.numberOutgoingEnergies() );
 
   CHECK( 3 == data1.outgoingEnergies().size() );
-  CHECK( 1e-5 == Approx( data1.outgoingEnergies().front() ) );
-  CHECK( 20. == Approx( data1.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-5, WithinRel( data1.outgoingEnergies().front() ) );
+  CHECK_THAT( 20., WithinRel( data1.outgoingEnergies().back() ) );
 
   CHECK( 3 == data1.pdf().size() );
-  CHECK( .5 == Approx( data1.pdf().front() ) );
-  CHECK( .5 == Approx( data1.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data1.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data1.pdf().back() ) );
 
   CHECK( 3 == data1.cdf().size() );
-  CHECK( 0. == Approx( data1.cdf().front() ) );
-  CHECK( 1. == Approx( data1.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data1.cdf().back() ) );
 
   auto data2 = chunk.distribution(2);
-  CHECK( 1. == Approx( data2.energyOrCosine() ) );
+  CHECK_THAT( 1., WithinRel( data2.energyOrCosine() ) );
   CHECK( 1 == data2.interpolation() );
   CHECK( 2 == data2.numberOutgoingEnergies() );
 
   CHECK( 2 == data2.outgoingEnergies().size() );
-  CHECK( 1e-3 == Approx( data2.outgoingEnergies().front() ) );
-  CHECK( 15. == Approx( data2.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-3, WithinRel( data2.outgoingEnergies().front() ) );
+  CHECK_THAT( 15., WithinRel( data2.outgoingEnergies().back() ) );
 
   CHECK( 2 == data2.pdf().size() );
-  CHECK( .5 == Approx( data2.pdf().front() ) );
-  CHECK( .5 == Approx( data2.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data2.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data2.pdf().back() ) );
 
   CHECK( 2 == data2.cdf().size() );
-  CHECK( 0. == Approx( data2.cdf().front() ) );
-  CHECK( 1. == Approx( data2.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data2.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data2.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedAngularDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedAngularDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedAngularDistribution.test TabulatedAngularDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedAngularDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedAngularDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedAngularDistribution COMMAND ACEtk.continuous.TabulatedAngularDistribution.test )
+add_cpp_test( continuous.TabulatedAngularDistribution TabulatedAngularDistribution.test.cpp )

--- a/src/ACEtk/continuous/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
+++ b/src/ACEtk/continuous/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedAngularDistribution.hpp"
 
 // other includes
@@ -41,7 +44,7 @@ SCENARIO( "TabulatedAngularDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -61,7 +64,7 @@ SCENARIO( "TabulatedAngularDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -81,19 +84,19 @@ void verifyChunk( const TabulatedAngularDistribution& chunk ) {
   CHECK( 11 == chunk.length() );
   CHECK( "TabulatedAngularDistribution" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
   CHECK( 2 == chunk.interpolation() );
   CHECK( 3 == chunk.numberCosines() );
 
   CHECK( 3 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines().front() ) );
-  CHECK( +1. == Approx( chunk.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( chunk.cosines().back() ) );
 
   CHECK( 3 == chunk.pdf().size() );
-  CHECK( .5 == Approx( chunk.pdf().front() ) );
-  CHECK( .5 == Approx( chunk.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 0. == Approx( chunk.cdf().front() ) );
-  CHECK( 1. == Approx( chunk.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedAngularDistributionWithProbability/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedAngularDistributionWithProbability/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedAngularDistributionWithProbability.test TabulatedAngularDistributionWithProbability.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedAngularDistributionWithProbability.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedAngularDistributionWithProbability.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedAngularDistributionWithProbability COMMAND ACEtk.continuous.TabulatedAngularDistributionWithProbability.test )
+add_cpp_test( continuous.TabulatedAngularDistributionWithProbability TabulatedAngularDistributionWithProbability.test.cpp )

--- a/src/ACEtk/continuous/TabulatedAngularDistributionWithProbability/test/TabulatedAngularDistributionWithProbability.test.cpp
+++ b/src/ACEtk/continuous/TabulatedAngularDistributionWithProbability/test/TabulatedAngularDistributionWithProbability.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedAngularDistributionWithProbability.hpp"
 
 // other includes
@@ -45,7 +48,7 @@ SCENARIO( "TabulatedAngularDistributionWithProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -68,7 +71,7 @@ SCENARIO( "TabulatedAngularDistributionWithProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -88,21 +91,21 @@ void verifyChunk( const TabulatedAngularDistributionWithProbability& chunk ) {
   CHECK( 11 == chunk.length() );
   CHECK( "TabulatedAngularDistribution" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
-  CHECK( .5 == Approx( chunk.probability() ) );
-  CHECK( .75 == Approx( chunk.cumulativeProbability() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
+  CHECK_THAT( .5, WithinRel( chunk.probability() ) );
+  CHECK_THAT( .75, WithinRel( chunk.cumulativeProbability() ) );
   CHECK( 2 == chunk.interpolation() );
   CHECK( 3 == chunk.numberCosines() );
 
   CHECK( 3 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines().front() ) );
-  CHECK( +1. == Approx( chunk.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( chunk.cosines().back() ) );
 
   CHECK( 3 == chunk.pdf().size() );
-  CHECK( .5 == Approx( chunk.pdf().front() ) );
-  CHECK( .5 == Approx( chunk.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 0. == Approx( chunk.cdf().front() ) );
-  CHECK( 1. == Approx( chunk.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedEnergyAngleDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedEnergyAngleDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedEnergyAngleDistribution.test TabulatedEnergyAngleDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedEnergyAngleDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedEnergyAngleDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedEnergyAngleDistribution COMMAND ACEtk.continuous.TabulatedEnergyAngleDistribution.test )
+add_cpp_test( continuous.TabulatedEnergyAngleDistribution TabulatedEnergyAngleDistribution.test.cpp )

--- a/src/ACEtk/continuous/TabulatedEnergyAngleDistribution/test/TabulatedEnergyAngleDistribution.test.cpp
+++ b/src/ACEtk/continuous/TabulatedEnergyAngleDistribution/test/TabulatedEnergyAngleDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedEnergyAngleDistribution.hpp"
 
 // other includes
@@ -47,7 +50,7 @@ SCENARIO( "TabulatedEnergyAngleDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -67,7 +70,7 @@ SCENARIO( "TabulatedEnergyAngleDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -92,7 +95,7 @@ void verifyChunk( const TabulatedEnergyAngleDistribution& chunk ) {
   CHECK( 29 == chunk.length() );
   CHECK( "TabulatedEnergyAngleDistribution" == chunk.name() );
 
-  CHECK( 1.1 == Approx( chunk.incidentEnergy() ) );
+  CHECK_THAT( 1.1, WithinRel( chunk.incidentEnergy() ) );
 
   CHECK( 2 == chunk.interpolation() );
 
@@ -101,25 +104,25 @@ void verifyChunk( const TabulatedEnergyAngleDistribution& chunk ) {
   CHECK( 2 == chunk.distributions().size() );
 
   CHECK( 2 == chunk.outgoingEnergies().size() );
-  CHECK( 2.1 == Approx( chunk.outgoingEnergies()[0] ) );
-  CHECK( 20. == Approx( chunk.outgoingEnergies()[1] ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.outgoingEnergies()[0] ) );
+  CHECK_THAT( 20., WithinRel( chunk.outgoingEnergies()[1] ) );
 
   CHECK( 2 == chunk.pdf().size() );
-  CHECK( 0.5 == Approx( chunk.pdf()[0] ) );
-  CHECK( 0.5 == Approx( chunk.pdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.pdf()[0] ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.pdf()[1] ) );
 
   CHECK( 2 == chunk.cdf().size() );
-  CHECK( 0.5 == Approx( chunk.cdf()[0] ) );
-  CHECK( 1.0 == Approx( chunk.cdf()[1] ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.cdf()[0] ) );
+  CHECK_THAT( 1.0, WithinRel( chunk.cdf()[1] ) );
 
-  CHECK( 2.1 == Approx( chunk.outgoingEnergy(1) ) );
-  CHECK( 20. == Approx( chunk.outgoingEnergy(2) ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.outgoingEnergy(1) ) );
+  CHECK_THAT( 20., WithinRel( chunk.outgoingEnergy(2) ) );
 
-  CHECK( 0.5 == Approx( chunk.probability(1) ) );
-  CHECK( 0.5 == Approx( chunk.probability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.probability(1) ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.probability(2) ) );
 
-  CHECK( 0.5 == Approx( chunk.cumulativeProbability(1) ) );
-  CHECK( 1.0 == Approx( chunk.cumulativeProbability(2) ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.cumulativeProbability(1) ) );
+  CHECK_THAT( 1.0, WithinRel( chunk.cumulativeProbability(2) ) );
 
   CHECK( 31 == chunk.LOCC(1) );
   CHECK( 42 == chunk.LOCC(2) );
@@ -130,40 +133,40 @@ void verifyChunk( const TabulatedEnergyAngleDistribution& chunk ) {
   CHECK( 22 == chunk.relativeDistributionLocator(2) );
 
   auto data1 = chunk.distribution(1);
-  CHECK( 2.1 == Approx( data1.energy() ) );
-  CHECK( 0.5 == Approx( data1.probability() ) );
-  CHECK( 0.5 == Approx( data1.cumulativeProbability() ) );
+  CHECK_THAT( 2.1, WithinRel( data1.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data1.probability() ) );
+  CHECK_THAT( 0.5, WithinRel( data1.cumulativeProbability() ) );
   CHECK( 2 == data1.interpolation() );
   CHECK( 3 == data1.numberCosines() );
 
   CHECK( 3 == data1.cosines().size() );
-  CHECK( -1. == Approx( data1.cosines().front() ) );
-  CHECK( +1. == Approx( data1.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data1.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data1.cosines().back() ) );
 
   CHECK( 3 == data1.pdf().size() );
-  CHECK( .5 == Approx( data1.pdf().front() ) );
-  CHECK( .5 == Approx( data1.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data1.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data1.pdf().back() ) );
 
   CHECK( 3 == data1.cdf().size() );
-  CHECK( 0. == Approx( data1.cdf().front() ) );
-  CHECK( 1. == Approx( data1.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data1.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data1.cdf().back() ) );
 
   auto data2 = chunk.distribution(2);
-  CHECK( 20 == Approx( data2.energy() ) );
-  CHECK( 0.5 == Approx( data1.probability() ) );
-  CHECK( 0.5 == Approx( data1.cumulativeProbability() ) );
+  CHECK_THAT( 20, WithinRel( data2.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( data1.probability() ) );
+  CHECK_THAT( 0.5, WithinRel( data1.cumulativeProbability() ) );
   CHECK( 1 == data2.interpolation() );
   CHECK( 2 == data2.numberCosines() );
 
   CHECK( 2 == data2.cosines().size() );
-  CHECK( -1. == Approx( data2.cosines().front() ) );
-  CHECK( +1. == Approx( data2.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( data2.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( data2.cosines().back() ) );
 
   CHECK( 2 == data2.pdf().size() );
-  CHECK( .5 == Approx( data2.pdf().front() ) );
-  CHECK( .5 == Approx( data2.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( data2.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( data2.pdf().back() ) );
 
   CHECK( 2 == data2.cdf().size() );
-  CHECK( 0. == Approx( data2.cdf().front() ) );
-  CHECK( 1. == Approx( data2.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( data2.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( data2.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedEnergyDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedEnergyDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedEnergyDistribution.test TabulatedEnergyDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedEnergyDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedEnergyDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedEnergyDistribution COMMAND ACEtk.continuous.TabulatedEnergyDistribution.test )
+add_cpp_test( continuous.TabulatedEnergyDistribution TabulatedEnergyDistribution.test.cpp )

--- a/src/ACEtk/continuous/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
+++ b/src/ACEtk/continuous/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedEnergyDistribution.hpp"
 
 // other includes
@@ -44,7 +47,7 @@ SCENARIO( "TabulatedEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -65,7 +68,7 @@ SCENARIO( "TabulatedEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -85,20 +88,20 @@ void verifyChunk( const TabulatedEnergyDistribution& chunk ) {
   CHECK( 11 == chunk.length() );
   CHECK( "TabulatedEnergyDistribution" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energyOrCosine() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energyOrCosine() ) );
   CHECK( 2 == chunk.interpolation() );
   CHECK( 3 == chunk.numberDiscretePhotonLines() );
   CHECK( 3 == chunk.numberOutgoingEnergies() );
 
   CHECK( 3 == chunk.outgoingEnergies().size() );
-  CHECK( 1e-11 == Approx( chunk.outgoingEnergies().front() ) );
-  CHECK( 20. == Approx( chunk.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.outgoingEnergies().front() ) );
+  CHECK_THAT( 20., WithinRel( chunk.outgoingEnergies().back() ) );
 
   CHECK( 3 == chunk.pdf().size() );
-  CHECK( .5 == Approx( chunk.pdf().front() ) );
-  CHECK( .5 == Approx( chunk.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 0. == Approx( chunk.cdf().front() ) );
-  CHECK( 1. == Approx( chunk.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedFissionMultiplicity/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedFissionMultiplicity/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedFissionMultiplicity.test TabulatedFissionMultiplicity.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedFissionMultiplicity.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedFissionMultiplicity.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedFissionMultiplicity COMMAND ACEtk.continuous.TabulatedFissionMultiplicity.test )
+add_cpp_test( continuous.TabulatedFissionMultiplicity TabulatedFissionMultiplicity.test.cpp )

--- a/src/ACEtk/continuous/TabulatedFissionMultiplicity/test/TabulatedFissionMultiplicity.test.cpp
+++ b/src/ACEtk/continuous/TabulatedFissionMultiplicity/test/TabulatedFissionMultiplicity.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedFissionMultiplicity.hpp"
 
 // other includes
@@ -37,7 +40,7 @@ SCENARIO( "TabulatedFissionMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +60,7 @@ SCENARIO( "TabulatedFissionMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -67,7 +70,7 @@ SCENARIO( "TabulatedFissionMultiplicity" ) {
 std::vector< double > chunk() {
 
   return {                  2,                   0,                   3,
-            1.00000000000E-11,   1.00000000000E+00,   2.00000000000E+01,   2.35000000000E+00,
+            1.00000000000E-05,   1.00000000000E+00,   2.00000000000E+01,   2.35000000000E+00,
             2.55000000000E+00,   7.00000000000E+00 };
 }
 
@@ -98,12 +101,12 @@ void verifyChunk( const TabulatedFissionMultiplicity& chunk ) {
   CHECK( 3 == chunk.numberValues() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1e-11 == Approx( chunk.energies()[0] ) );
-  CHECK( 1. == Approx( chunk.energies()[1] ) );
-  CHECK( 20. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1e-5, WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.multiplicities().size() );
-  CHECK( 2.35 == Approx( chunk.multiplicities()[0] ) );
-  CHECK( 2.55 == Approx( chunk.multiplicities()[1] ) );
-  CHECK( 7. == Approx( chunk.multiplicities()[2] ) );
+  CHECK_THAT( 2.35, WithinRel( chunk.multiplicities()[0] ) );
+  CHECK_THAT( 2.55, WithinRel( chunk.multiplicities()[1] ) );
+  CHECK_THAT( 7., WithinRel( chunk.multiplicities()[2] ) );
 }

--- a/src/ACEtk/continuous/TabulatedKalbachMannDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedKalbachMannDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedKalbachMannDistribution.test TabulatedKalbachMannDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedKalbachMannDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedKalbachMannDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedKalbachMannDistribution COMMAND ACEtk.continuous.TabulatedKalbachMannDistribution.test )
+add_cpp_test( continuous.TabulatedKalbachMannDistribution TabulatedKalbachMannDistribution.test.cpp )

--- a/src/ACEtk/continuous/TabulatedKalbachMannDistribution/test/TabulatedKalbachMannDistribution.test.cpp
+++ b/src/ACEtk/continuous/TabulatedKalbachMannDistribution/test/TabulatedKalbachMannDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedKalbachMannDistribution.hpp"
 
 // other includes
@@ -48,7 +51,7 @@ SCENARIO( "TabulatedKalbachMannDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -69,7 +72,7 @@ SCENARIO( "TabulatedKalbachMannDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,28 +94,28 @@ void verifyChunk( const TabulatedKalbachMannDistribution& chunk ) {
   CHECK( 17 == chunk.length() );
   CHECK( "TabulatedKalbachMannDistribution" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.incidentEnergy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.incidentEnergy() ) );
   CHECK( 2 == chunk.interpolation() );
   CHECK( 3 == chunk.numberDiscretePhotonLines() );
   CHECK( 3 == chunk.numberOutgoingEnergies() );
 
   CHECK( 3 == chunk.outgoingEnergies().size() );
-  CHECK( 1e-11 == Approx( chunk.outgoingEnergies().front() ) );
-  CHECK( 20. == Approx( chunk.outgoingEnergies().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.outgoingEnergies().front() ) );
+  CHECK_THAT( 20., WithinRel( chunk.outgoingEnergies().back() ) );
 
   CHECK( 3 == chunk.pdf().size() );
-  CHECK( .5 == Approx( chunk.pdf().front() ) );
-  CHECK( .5 == Approx( chunk.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 0. == Approx( chunk.cdf().front() ) );
-  CHECK( 1. == Approx( chunk.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf().back() ) );
 
   CHECK( 3 == chunk.precompoundFractionValues().size() );
-  CHECK( 1. == Approx( chunk.precompoundFractionValues().front() ) );
-  CHECK( 3. == Approx( chunk.precompoundFractionValues().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.precompoundFractionValues().front() ) );
+  CHECK_THAT( 3., WithinRel( chunk.precompoundFractionValues().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 4. == Approx( chunk.angularDistributionSlopeValues().front() ) );
-  CHECK( 6. == Approx( chunk.angularDistributionSlopeValues().back() ) );
+  CHECK_THAT( 4., WithinRel( chunk.angularDistributionSlopeValues().front() ) );
+  CHECK_THAT( 6., WithinRel( chunk.angularDistributionSlopeValues().back() ) );
 }

--- a/src/ACEtk/continuous/TabulatedMultiplicity/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedMultiplicity/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedMultiplicity.test TabulatedMultiplicity.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedMultiplicity.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedMultiplicity.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedMultiplicity COMMAND ACEtk.continuous.TabulatedMultiplicity.test )
+add_cpp_test( continuous.TabulatedMultiplicity TabulatedMultiplicity.test.cpp )

--- a/src/ACEtk/continuous/TabulatedMultiplicity/test/TabulatedMultiplicity.test.cpp
+++ b/src/ACEtk/continuous/TabulatedMultiplicity/test/TabulatedMultiplicity.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedMultiplicity.hpp"
 
 // other includes
@@ -40,7 +43,7 @@ SCENARIO( "TabulatedMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "TabulatedMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,12 +98,12 @@ void verifyChunk( const TabulatedMultiplicity& chunk ) {
   CHECK( 3 == chunk.numberEnergyPoints() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1. == Approx( chunk.energies()[0] ) );
-  CHECK( 3. == Approx( chunk.energies()[1] ) );
-  CHECK( 5. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 5., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.multiplicities().size() );
-  CHECK( 2. == Approx( chunk.multiplicities()[0] ) );
-  CHECK( 4. == Approx( chunk.multiplicities()[1] ) );
-  CHECK( 6. == Approx( chunk.multiplicities()[2] ) );
+  CHECK_THAT( 2., WithinRel( chunk.multiplicities()[0] ) );
+  CHECK_THAT( 4., WithinRel( chunk.multiplicities()[1] ) );
+  CHECK_THAT( 6., WithinRel( chunk.multiplicities()[2] ) );
 }

--- a/src/ACEtk/continuous/TabulatedSecondaryParticleMultiplicity/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TabulatedSecondaryParticleMultiplicity/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TabulatedSecondaryParticleMultiplicity.test TabulatedSecondaryParticleMultiplicity.test.cpp )
-target_compile_options( ACEtk.continuous.TabulatedSecondaryParticleMultiplicity.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TabulatedSecondaryParticleMultiplicity.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TabulatedSecondaryParticleMultiplicity COMMAND ACEtk.continuous.TabulatedSecondaryParticleMultiplicity.test )
+add_cpp_test( continuous.TabulatedSecondaryParticleMultiplicity TabulatedSecondaryParticleMultiplicity.test.cpp )

--- a/src/ACEtk/continuous/TabulatedSecondaryParticleMultiplicity/test/TabulatedSecondaryParticleMultiplicity.test.cpp
+++ b/src/ACEtk/continuous/TabulatedSecondaryParticleMultiplicity/test/TabulatedSecondaryParticleMultiplicity.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TabulatedSecondaryParticleMultiplicity.hpp"
 
 // other includes
@@ -46,7 +49,7 @@ SCENARIO( "TabulatedSecondaryParticleMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -66,7 +69,7 @@ SCENARIO( "TabulatedSecondaryParticleMultiplicity" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -111,12 +114,12 @@ void verifyChunk( const TabulatedSecondaryParticleMultiplicity& chunk ) {
   CHECK( 7 == chunk.numberValues() );
 
   CHECK( 7 == chunk.energies().size() );
-  CHECK( 0.7742381 == Approx( chunk.energies().front() ) );
-  CHECK( 1. == Approx( chunk.energies()[3] ) );
-  CHECK( 20. == Approx( chunk.energies().back() ) );
+  CHECK_THAT( 0.7742381, WithinRel( chunk.energies().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[3] ) );
+  CHECK_THAT( 20., WithinRel( chunk.energies().back() ) );
 
   CHECK( 7 == chunk.multiplicities().size() );
-  CHECK( 0. == Approx( chunk.multiplicities().front() ) );
-  CHECK( 0.119 == Approx( chunk.multiplicities()[3] ) );
-  CHECK( 0. == Approx( chunk.multiplicities().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.multiplicities().front() ) );
+  CHECK_THAT( 0.119, WithinRel( chunk.multiplicities()[3] ) );
+  CHECK_THAT( 0., WithinRel( chunk.multiplicities().back() ) );
 }

--- a/src/ACEtk/continuous/TwoBodyTransferDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/continuous/TwoBodyTransferDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.continuous.TwoBodyTransferDistribution.test TwoBodyTransferDistribution.test.cpp )
-target_compile_options( ACEtk.continuous.TwoBodyTransferDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.continuous.TwoBodyTransferDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.continuous.TwoBodyTransferDistribution COMMAND ACEtk.continuous.TwoBodyTransferDistribution.test )
+add_cpp_test( continuous.TwoBodyTransferDistribution TwoBodyTransferDistribution.test.cpp )

--- a/src/ACEtk/continuous/TwoBodyTransferDistribution/test/TwoBodyTransferDistribution.test.cpp
+++ b/src/ACEtk/continuous/TwoBodyTransferDistribution/test/TwoBodyTransferDistribution.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/continuous/TwoBodyTransferDistribution.hpp"
 
 // other includes
@@ -38,7 +41,7 @@ SCENARIO( "TwoBodyTransferDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +62,7 @@ SCENARIO( "TwoBodyTransferDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -80,9 +83,9 @@ void verifyChunk( const TwoBodyTransferDistribution& chunk ) {
   CHECK( EnergyDistributionType::TwoBodyTransfer == chunk.LAW() );
   CHECK( EnergyDistributionType::TwoBodyTransfer == chunk.type() );
 
-  CHECK( 2.249999e-3 == Approx( chunk.minimumIncidentEnergy() ) );
-  CHECK( 20. == Approx( chunk.maximumIncidentEnergy() ) );
+  CHECK_THAT( 2.249999e-3, WithinRel( chunk.minimumIncidentEnergy() ) );
+  CHECK_THAT( 20., WithinRel( chunk.maximumIncidentEnergy() ) );
 
-  CHECK( 7.71295800000E-05 == Approx( chunk.C1() ) );
-  CHECK( .9914722 == Approx( chunk.C2() ) );
+  CHECK_THAT( 7.71295800000E-05, WithinRel( chunk.C1() ) );
+  CHECK_THAT( .9914722, WithinRel( chunk.C2() ) );
 }

--- a/src/ACEtk/dosimetry/CrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/dosimetry/CrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.dosimetry.CrossSectionBlock.test CrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.dosimetry.CrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.dosimetry.CrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.dosimetry.CrossSectionBlock COMMAND ACEtk.dosimetry.CrossSectionBlock.test )
+add_cpp_test( dosimetry.CrossSectionBlock CrossSectionBlock.test.cpp )

--- a/src/ACEtk/dosimetry/CrossSectionBlock/test/CrossSectionBlock.test.cpp
+++ b/src/ACEtk/dosimetry/CrossSectionBlock/test/CrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/dosimetry/CrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -44,7 +48,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -63,7 +67,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -101,18 +105,18 @@ void verifyChunk( const CrossSectionBlock& chunk ) {
   CHECK( 4 == xs.numberEnergyPoints() );
   CHECK( 4 == xs.energies().size() );
   CHECK( 4 == xs.crossSections().size() );
-  CHECK( 1.8961 == Approx( xs.energies().front() ) );
-  CHECK( 20. == Approx( xs.energies().back() ) );
-  CHECK( 0. == Approx( xs.crossSections().front() ) );
-  CHECK( 0.0322 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 1.8961, WithinRel( xs.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( xs.energies().back() ) );
+  CHECK_THAT( 0., WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 0.0322, WithinRel( xs.crossSections().back() ) );
 
   xs = chunk.crossSectionData(2);
   CHECK( 0 == xs.NB() );
   CHECK( 3 == xs.numberEnergyPoints() );
   CHECK( 3 == xs.energies().size() );
   CHECK( 3 == xs.crossSections().size() );
-  CHECK( 3.2487 == Approx( xs.energies().front() ) );
-  CHECK( 20. == Approx( xs.energies().back() ) );
-  CHECK( 0. == Approx( xs.crossSections().front() ) );
-  CHECK( 0.0498 == Approx( xs.crossSections().back() ) );
+  CHECK_THAT( 3.2487, WithinRel( xs.energies().front() ) );
+  CHECK_THAT( 20., WithinRel( xs.energies().back() ) );
+  CHECK_THAT( 0., WithinRel( xs.crossSections().front() ) );
+  CHECK_THAT( 0.0498, WithinRel( xs.crossSections().back() ) );
 }

--- a/src/ACEtk/dosimetry/CrossSectionBlock/test/CrossSectionBlock.test.cpp
+++ b/src/ACEtk/dosimetry/CrossSectionBlock/test/CrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/dosimetry/CrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/dosimetry/CrossSectionData/test/CMakeLists.txt
+++ b/src/ACEtk/dosimetry/CrossSectionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.dosimetry.CrossSectionData.test CrossSectionData.test.cpp )
-target_compile_options( ACEtk.dosimetry.CrossSectionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.dosimetry.CrossSectionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.dosimetry.CrossSectionData COMMAND ACEtk.dosimetry.CrossSectionData.test )
+add_cpp_test( dosimetry.CrossSectionData CrossSectionData.test.cpp )

--- a/src/ACEtk/dosimetry/CrossSectionData/test/CrossSectionData.test.cpp
+++ b/src/ACEtk/dosimetry/CrossSectionData/test/CrossSectionData.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/dosimetry/CrossSectionData.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -40,7 +44,7 @@ SCENARIO( "CrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +63,7 @@ SCENARIO( "CrossSectionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,12 +99,12 @@ void verifyChunk( const CrossSectionData& chunk ) {
   CHECK( 3 == chunk.numberEnergyPoints() );
 
   CHECK( 3 == chunk.energies().size() );
-  CHECK( 1. == Approx( chunk.energies()[0] ) );
-  CHECK( 3. == Approx( chunk.energies()[1] ) );
-  CHECK( 5. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT( 3., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 5., WithinRel( chunk.energies()[2] ) );
 
   CHECK( 3 == chunk.crossSections().size() );
-  CHECK( 2. == Approx( chunk.crossSections()[0] ) );
-  CHECK( 4. == Approx( chunk.crossSections()[1] ) );
-  CHECK( 6. == Approx( chunk.crossSections()[2] ) );
+  CHECK_THAT( 2., WithinRel( chunk.crossSections()[0] ) );
+  CHECK_THAT( 4., WithinRel( chunk.crossSections()[1] ) );
+  CHECK_THAT( 6., WithinRel( chunk.crossSections()[2] ) );
 }

--- a/src/ACEtk/dosimetry/CrossSectionData/test/CrossSectionData.test.cpp
+++ b/src/ACEtk/dosimetry/CrossSectionData/test/CrossSectionData.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/dosimetry/CrossSectionData.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/BremsstrahlungBlock/test/BremsstrahlungBlock.test.cpp
+++ b/src/ACEtk/electron/BremsstrahlungBlock/test/BremsstrahlungBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/BremsstrahlungBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -37,7 +41,7 @@ SCENARIO( "BremsstrahlungBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +61,7 @@ SCENARIO( "BremsstrahlungBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -82,11 +86,11 @@ void verifyChunk( const BremsstrahlungBlock& chunk ) {
   CHECK( 3 == chunk.energies().size() );
   CHECK( 3 == chunk.energyAfterBremsstrahlung().size() );
 
-  CHECK(  10. == Approx( chunk.energies()[0] ) );
-  CHECK(  20. == Approx( chunk.energies()[1] ) );
-  CHECK( 200. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT(  10., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT(  20., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 200., WithinRel( chunk.energies()[2] ) );
 
-  CHECK(   1. == Approx( chunk.energyAfterBremsstrahlung()[0] ) );
-  CHECK(   2. == Approx( chunk.energyAfterBremsstrahlung()[1] ) );
-  CHECK(   3. == Approx( chunk.energyAfterBremsstrahlung()[2] ) );
+  CHECK_THAT(   1., WithinRel( chunk.energyAfterBremsstrahlung()[0] ) );
+  CHECK_THAT(   2., WithinRel( chunk.energyAfterBremsstrahlung()[1] ) );
+  CHECK_THAT(   3., WithinRel( chunk.energyAfterBremsstrahlung()[2] ) );
 }

--- a/src/ACEtk/electron/BremsstrahlungBlock/test/BremsstrahlungBlock.test.cpp
+++ b/src/ACEtk/electron/BremsstrahlungBlock/test/BremsstrahlungBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/BremsstrahlungBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/BremsstrahlungBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/BremsstrahlungBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.PhotoatomicElectronBremsstrahlungBlock.test BremsstrahlungBlock.test.cpp )
-target_compile_options( ACEtk.electron.PhotoatomicElectronBremsstrahlungBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.PhotoatomicElectronBremsstrahlungBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.PhotoatomicElectronBremsstrahlungBlock COMMAND ACEtk.electron.PhotoatomicElectronBremsstrahlungBlock.test )
+add_cpp_test( electron.BremsstrahlungBlock BremsstrahlungBlock.test.cpp )

--- a/src/ACEtk/electron/ElasticAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/ElasticAngularDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.ElasticAngularDistributionBlock.test ElasticAngularDistributionBlock.test.cpp )
-target_compile_options( ACEtk.electron.ElasticAngularDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.ElasticAngularDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.ElasticAngularDistributionBlock COMMAND ACEtk.electron.ElasticAngularDistributionBlock.test )
+add_cpp_test( electron.ElasticAngularDistributionBlock ElasticAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/electron/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
+++ b/src/ACEtk/electron/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/ElasticAngularDistributionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +45,7 @@ SCENARIO( "ElasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +64,7 @@ SCENARIO( "ElasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/electron/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
+++ b/src/ACEtk/electron/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/ElasticAngularDistributionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/ElasticCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/ElasticCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.ElasticCrossSectionBlock.test ElasticCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.electron.ElasticCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.ElasticCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.ElasticCrossSectionBlock COMMAND ACEtk.electron.ElasticCrossSectionBlock.test )
+add_cpp_test( electron.ElasticCrossSectionBlock ElasticCrossSectionBlock.test.cpp )

--- a/src/ACEtk/electron/ElasticCrossSectionBlock/test/ElasticCrossSectionBlock.test.cpp
+++ b/src/ACEtk/electron/ElasticCrossSectionBlock/test/ElasticCrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/ElasticCrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/ElasticCrossSectionBlock/test/ElasticCrossSectionBlock.test.cpp
+++ b/src/ACEtk/electron/ElasticCrossSectionBlock/test/ElasticCrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/ElasticCrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -37,7 +41,7 @@ SCENARIO( "ElasticCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +61,7 @@ SCENARIO( "ElasticCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -83,10 +87,10 @@ void verifyChunk( const ElasticCrossSectionBlock& chunk ) {
   CHECK( 3 == chunk.transport().size() );
   CHECK( 3 == chunk.total().size() );
 
-  CHECK(   1. == Approx( chunk.transport()[0] ) );
-  CHECK(   2. == Approx( chunk.transport()[1] ) );
-  CHECK(   3. == Approx( chunk.transport()[2] ) );
-  CHECK(   4. == Approx( chunk.total()[0] ) );
-  CHECK(   5. == Approx( chunk.total()[1] ) );
-  CHECK(   6. == Approx( chunk.total()[2] ) );
+  CHECK_THAT(   1., WithinRel( chunk.transport()[0] ) );
+  CHECK_THAT(   2., WithinRel( chunk.transport()[1] ) );
+  CHECK_THAT(   3., WithinRel( chunk.transport()[2] ) );
+  CHECK_THAT(   4., WithinRel( chunk.total()[0] ) );
+  CHECK_THAT(   5., WithinRel( chunk.total()[1] ) );
+  CHECK_THAT(   6., WithinRel( chunk.total()[2] ) );
 }

--- a/src/ACEtk/electron/ElectronShellBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/ElectronShellBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.ElectronShellBlock.test ElectronShellBlock.test.cpp )
-target_compile_options( ACEtk.electron.ElectronShellBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.ElectronShellBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.ElectronShellBlock COMMAND ACEtk.electron.ElectronShellBlock.test )
+add_cpp_test( electron.ElectronShellBlock ElectronShellBlock.test.cpp )

--- a/src/ACEtk/electron/ElectronShellBlock/test/ElectronShellBlock.test.cpp
+++ b/src/ACEtk/electron/ElectronShellBlock/test/ElectronShellBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/ElectronShellBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/ElectronShellBlock/test/ElectronShellBlock.test.cpp
+++ b/src/ACEtk/electron/ElectronShellBlock/test/ElectronShellBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/ElectronShellBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -39,7 +43,7 @@ SCENARIO( "ElectronShellBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -59,7 +63,7 @@ SCENARIO( "ElectronShellBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -82,17 +86,17 @@ void verifyChunk( const ElectronShellBlock& chunk ) {
   CHECK( 2 == chunk.NSH() );
   CHECK( 2 == chunk.numberElectronShells() );
 
-  CHECK( 2 == Approx( chunk.numberElectrons()[0] ) );
-  CHECK( 1 == Approx( chunk.numberElectrons()[1] ) );
-  CHECK( 5.480000000000e-05 == Approx( chunk.bindingEnergies()[0] ) );
-  CHECK( 1.000000000000e-06 == Approx( chunk.bindingEnergies()[1] ) );
-  CHECK( 6.666666666667e-01 == Approx( chunk.interactionProbabilities()[0] ) );
-  CHECK( 3.333333333333e-01 == Approx( chunk.interactionProbabilities()[1] ) );
+  CHECK( 2 == chunk.numberElectrons()[0] );
+  CHECK( 1 == chunk.numberElectrons()[1] );
+  CHECK_THAT( 5.480000000000e-05, WithinRel( chunk.bindingEnergies()[0] ) );
+  CHECK_THAT( 1.000000000000e-06, WithinRel( chunk.bindingEnergies()[1] ) );
+  CHECK_THAT( 6.666666666667e-01, WithinRel( chunk.interactionProbabilities()[0] ) );
+  CHECK_THAT( 3.333333333333e-01, WithinRel( chunk.interactionProbabilities()[1] ) );
 
   CHECK( 2 == chunk.numberElectronsPerShell( 1 ) );
   CHECK( 1 == chunk.numberElectronsPerShell( 2 ) );
-  CHECK( 5.480000000000e-05 == Approx( chunk.bindingEnergy( 1 ) ) );
-  CHECK( 1.000000000000e-06 == Approx( chunk.bindingEnergy( 2 ) ) );
-  CHECK( 6.666666666667e-01 == Approx( chunk.interactionProbability( 1 ) ) );
-  CHECK( 3.333333333333e-01 == Approx( chunk.interactionProbability( 2 ) ) );
+  CHECK_THAT( 5.480000000000e-05, WithinRel( chunk.bindingEnergy( 1 ) ) );
+  CHECK_THAT( 1.000000000000e-06, WithinRel( chunk.bindingEnergy( 2 ) ) );
+  CHECK_THAT( 6.666666666667e-01, WithinRel( chunk.interactionProbability( 1 ) ) );
+  CHECK_THAT( 3.333333333333e-01, WithinRel( chunk.interactionProbability( 2 ) ) );
 }

--- a/src/ACEtk/electron/ElectronSubshellBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/ElectronSubshellBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.ElectronSubshellBlock.test ElectronSubshellBlock.test.cpp )
-target_compile_options( ACEtk.electron.ElectronSubshellBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.ElectronSubshellBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.ElectronSubshellBlock COMMAND ACEtk.electron.ElectronSubshellBlock.test )
+add_cpp_test( electron.ElectronSubshellBlock ElectronSubshellBlock.test.cpp )

--- a/src/ACEtk/electron/ElectronSubshellBlock/test/ElectronSubshellBlock.test.cpp
+++ b/src/ACEtk/electron/ElectronSubshellBlock/test/ElectronSubshellBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/ElectronSubshellBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -46,7 +50,7 @@ SCENARIO( "ElectronSubshellBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -66,7 +70,7 @@ SCENARIO( "ElectronSubshellBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -115,27 +119,27 @@ void verifyChunk( const ElectronSubshellBlock& chunk ) {
   CHECK( 4 == chunk.populations()[3] );
   CHECK( 2 == chunk.populations()[4] );
 
-  CHECK( 1.2945e-3 == Approx( chunk.BE()[0] ) );
-  CHECK( 8.9460e-5 == Approx( chunk.BE()[1] ) );
-  CHECK( 5.6550e-5 == Approx( chunk.BE()[2] ) );
-  CHECK( 5.6240e-5 == Approx( chunk.BE()[3] ) );
-  CHECK( 6.8900e-6 == Approx( chunk.BE()[4] ) );
-  CHECK( 1.2945e-3 == Approx( chunk.bindingEnergies()[0] ) );
-  CHECK( 8.9460e-5 == Approx( chunk.bindingEnergies()[1] ) );
-  CHECK( 5.6550e-5 == Approx( chunk.bindingEnergies()[2] ) );
-  CHECK( 5.6240e-5 == Approx( chunk.bindingEnergies()[3] ) );
-  CHECK( 6.8900e-6 == Approx( chunk.bindingEnergies()[4] ) );
+  CHECK_THAT( 1.2945e-3, WithinRel( chunk.BE()[0] ) );
+  CHECK_THAT( 8.9460e-5, WithinRel( chunk.BE()[1] ) );
+  CHECK_THAT( 5.6550e-5, WithinRel( chunk.BE()[2] ) );
+  CHECK_THAT( 5.6240e-5, WithinRel( chunk.BE()[3] ) );
+  CHECK_THAT( 6.8900e-6, WithinRel( chunk.BE()[4] ) );
+  CHECK_THAT( 1.2945e-3, WithinRel( chunk.bindingEnergies()[0] ) );
+  CHECK_THAT( 8.9460e-5, WithinRel( chunk.bindingEnergies()[1] ) );
+  CHECK_THAT( 5.6550e-5, WithinRel( chunk.bindingEnergies()[2] ) );
+  CHECK_THAT( 5.6240e-5, WithinRel( chunk.bindingEnergies()[3] ) );
+  CHECK_THAT( 6.8900e-6, WithinRel( chunk.bindingEnergies()[4] ) );
 
-  CHECK( 1.666666666667e-1 == Approx( chunk.CV()[0] ) );
-  CHECK( 3.333333333333e-1 == Approx( chunk.CV()[1] ) );
-  CHECK( 5.000000000000e-1 == Approx( chunk.CV()[2] ) );
-  CHECK( 8.333333333333e-1 == Approx( chunk.CV()[3] ) );
-  CHECK( 1.000000000000e+0 == Approx( chunk.CV()[4] ) );
-  CHECK( 1.666666666667e-1 == Approx( chunk.vacancyProbabilities()[0] ) );
-  CHECK( 3.333333333333e-1 == Approx( chunk.vacancyProbabilities()[1] ) );
-  CHECK( 5.000000000000e-1 == Approx( chunk.vacancyProbabilities()[2] ) );
-  CHECK( 8.333333333333e-1 == Approx( chunk.vacancyProbabilities()[3] ) );
-  CHECK( 1.000000000000e+0 == Approx( chunk.vacancyProbabilities()[4] ) );
+  CHECK_THAT( 1.666666666667e-1, WithinRel( chunk.CV()[0] ) );
+  CHECK_THAT( 3.333333333333e-1, WithinRel( chunk.CV()[1] ) );
+  CHECK_THAT( 5.000000000000e-1, WithinRel( chunk.CV()[2] ) );
+  CHECK_THAT( 8.333333333333e-1, WithinRel( chunk.CV()[3] ) );
+  CHECK_THAT( 1.000000000000e+0, WithinRel( chunk.CV()[4] ) );
+  CHECK_THAT( 1.666666666667e-1, WithinRel( chunk.vacancyProbabilities()[0] ) );
+  CHECK_THAT( 3.333333333333e-1, WithinRel( chunk.vacancyProbabilities()[1] ) );
+  CHECK_THAT( 5.000000000000e-1, WithinRel( chunk.vacancyProbabilities()[2] ) );
+  CHECK_THAT( 8.333333333333e-1, WithinRel( chunk.vacancyProbabilities()[3] ) );
+  CHECK_THAT( 1.000000000000e+0, WithinRel( chunk.vacancyProbabilities()[4] ) );
 
   CHECK( 12 == chunk.NT()[0] );
   CHECK(  5 == chunk.NT()[1] );
@@ -160,17 +164,17 @@ void verifyChunk( const ElectronSubshellBlock& chunk ) {
   CHECK( 4 == chunk.population( 4 ) );
   CHECK( 2 == chunk.population( 5 ) );
 
-  CHECK( 1.2945e-3 == Approx( chunk.bindingEnergy( 1 ) ) );
-  CHECK( 8.9460e-5 == Approx( chunk.bindingEnergy( 2 ) ) );
-  CHECK( 5.6550e-5 == Approx( chunk.bindingEnergy( 3 ) ) );
-  CHECK( 5.6240e-5 == Approx( chunk.bindingEnergy( 4 ) ) );
-  CHECK( 6.8900e-6 == Approx( chunk.bindingEnergy( 5 ) ) );
+  CHECK_THAT( 1.2945e-3, WithinRel( chunk.bindingEnergy( 1 ) ) );
+  CHECK_THAT( 8.9460e-5, WithinRel( chunk.bindingEnergy( 2 ) ) );
+  CHECK_THAT( 5.6550e-5, WithinRel( chunk.bindingEnergy( 3 ) ) );
+  CHECK_THAT( 5.6240e-5, WithinRel( chunk.bindingEnergy( 4 ) ) );
+  CHECK_THAT( 6.8900e-6, WithinRel( chunk.bindingEnergy( 5 ) ) );
 
-  CHECK( 1.666666666667e-1 == Approx( chunk.vacancyProbability( 1 ) ) );
-  CHECK( 3.333333333333e-1 == Approx( chunk.vacancyProbability( 2 ) ) );
-  CHECK( 5.000000000000e-1 == Approx( chunk.vacancyProbability( 3 ) ) );
-  CHECK( 8.333333333333e-1 == Approx( chunk.vacancyProbability( 4 ) ) );
-  CHECK( 1.000000000000e+0 == Approx( chunk.vacancyProbability( 5 ) ) );
+  CHECK_THAT( 1.666666666667e-1, WithinRel( chunk.vacancyProbability( 1 ) ) );
+  CHECK_THAT( 3.333333333333e-1, WithinRel( chunk.vacancyProbability( 2 ) ) );
+  CHECK_THAT( 5.000000000000e-1, WithinRel( chunk.vacancyProbability( 3 ) ) );
+  CHECK_THAT( 8.333333333333e-1, WithinRel( chunk.vacancyProbability( 4 ) ) );
+  CHECK_THAT( 1.000000000000e+0, WithinRel( chunk.vacancyProbability( 5 ) ) );
 
   CHECK( 12 == chunk.numberTransitions( 1 ) );
   CHECK(  5 == chunk.numberTransitions( 2 ) );

--- a/src/ACEtk/electron/ElectronSubshellBlock/test/ElectronSubshellBlock.test.cpp
+++ b/src/ACEtk/electron/ElectronSubshellBlock/test/ElectronSubshellBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/ElectronSubshellBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/EnergyDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/EnergyDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.EnergyDistributionBlock.test EnergyDistributionBlock.test.cpp )
-target_compile_options( ACEtk.electron.EnergyDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.EnergyDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.EnergyDistributionBlock COMMAND ACEtk.electron.EnergyDistributionBlock.test )
+add_cpp_test( electron.EnergyDistributionBlock EnergyDistributionBlock.test.cpp )

--- a/src/ACEtk/electron/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
+++ b/src/ACEtk/electron/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/EnergyDistributionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
+++ b/src/ACEtk/electron/EnergyDistributionBlock/test/EnergyDistributionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/EnergyDistributionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +45,7 @@ SCENARIO( "EnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +64,7 @@ SCENARIO( "EnergyDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/electron/ExcitationBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/ExcitationBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.ExcitationBlock.test ExcitationBlock.test.cpp )
-target_compile_options( ACEtk.electron.ExcitationBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.ExcitationBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.ExcitationBlock COMMAND ACEtk.electron.ExcitationBlock.test )
+add_cpp_test( electron.ExcitationBlock ExcitationBlock.test.cpp )

--- a/src/ACEtk/electron/ExcitationBlock/test/ExcitationBlock.test.cpp
+++ b/src/ACEtk/electron/ExcitationBlock/test/ExcitationBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/ExcitationBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -37,7 +41,7 @@ SCENARIO( "ExcitationBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +61,7 @@ SCENARIO( "ExcitationBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -82,11 +86,11 @@ void verifyChunk( const ExcitationBlock& chunk ) {
   CHECK( 3 == chunk.energies().size() );
   CHECK( 3 == chunk.excitationEnergyLoss().size() );
 
-  CHECK(  10. == Approx( chunk.energies()[0] ) );
-  CHECK(  20. == Approx( chunk.energies()[1] ) );
-  CHECK( 200. == Approx( chunk.energies()[2] ) );
+  CHECK_THAT(  10., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT(  20., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 200., WithinRel( chunk.energies()[2] ) );
 
-  CHECK(   1. == Approx( chunk.excitationEnergyLoss()[0] ) );
-  CHECK(   2. == Approx( chunk.excitationEnergyLoss()[1] ) );
-  CHECK(   3. == Approx( chunk.excitationEnergyLoss()[2] ) );
+  CHECK_THAT(   1., WithinRel( chunk.excitationEnergyLoss()[0] ) );
+  CHECK_THAT(   2., WithinRel( chunk.excitationEnergyLoss()[1] ) );
+  CHECK_THAT(   3., WithinRel( chunk.excitationEnergyLoss()[2] ) );
 }

--- a/src/ACEtk/electron/ExcitationBlock/test/ExcitationBlock.test.cpp
+++ b/src/ACEtk/electron/ExcitationBlock/test/ExcitationBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/ExcitationBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/PrincipalCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/PrincipalCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.PrincipalCrossSectionBlock.test PrincipalCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.electron.PrincipalCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.PrincipalCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.PrincipalCrossSectionBlock COMMAND ACEtk.electron.PrincipalCrossSectionBlock.test )
+add_cpp_test( electron.PrincipalCrossSectionBlock PrincipalCrossSectionBlock.test.cpp )

--- a/src/ACEtk/electron/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/electron/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/PrincipalCrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/electron/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/PrincipalCrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -44,7 +48,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -64,7 +68,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -104,28 +108,28 @@ void verifyChunk( const PrincipalCrossSectionBlock& chunk ) {
   CHECK( 3 == chunk.electroionisation(1).size() );
   CHECK( 3 == chunk.electroionisation(2).size() );
 
-  CHECK(  10. == Approx( chunk.energies()[0] ) );
-  CHECK(  20. == Approx( chunk.energies()[1] ) );
-  CHECK( 200. == Approx( chunk.energies()[2] ) );
-  CHECK(  35. == Approx( chunk.total()[0] ) );
-  CHECK(  40. == Approx( chunk.total()[1] ) );
-  CHECK(  45. == Approx( chunk.total()[2] ) );
-  CHECK(   1. == Approx( chunk.elastic()[0] ) );
-  CHECK(   2. == Approx( chunk.elastic()[1] ) );
-  CHECK(   3. == Approx( chunk.elastic()[2] ) );
-  CHECK(   4. == Approx( chunk.bremsstrahlung()[0] ) );
-  CHECK(   5. == Approx( chunk.bremsstrahlung()[1] ) );
-  CHECK(   6. == Approx( chunk.bremsstrahlung()[2] ) );
-  CHECK(   7. == Approx( chunk.excitation()[0] ) );
-  CHECK(   8. == Approx( chunk.excitation()[1] ) );
-  CHECK(   9. == Approx( chunk.excitation()[2] ) );
-  CHECK(  23. == Approx( chunk.totalElectroionisation()[0] ) );
-  CHECK(  25. == Approx( chunk.totalElectroionisation()[1] ) );
-  CHECK(  27. == Approx( chunk.totalElectroionisation()[2] ) );
-  CHECK(  10. == Approx( chunk.electroionisation(1)[0] ) );
-  CHECK(  11. == Approx( chunk.electroionisation(1)[1] ) );
-  CHECK(  12. == Approx( chunk.electroionisation(1)[2] ) );
-  CHECK(  13. == Approx( chunk.electroionisation(2)[0] ) );
-  CHECK(  14. == Approx( chunk.electroionisation(2)[1] ) );
-  CHECK(  15. == Approx( chunk.electroionisation(2)[2] ) );
+  CHECK_THAT(  10., WithinRel( chunk.energies()[0] ) );
+  CHECK_THAT(  20., WithinRel( chunk.energies()[1] ) );
+  CHECK_THAT( 200., WithinRel( chunk.energies()[2] ) );
+  CHECK_THAT(  35., WithinRel( chunk.total()[0] ) );
+  CHECK_THAT(  40., WithinRel( chunk.total()[1] ) );
+  CHECK_THAT(  45., WithinRel( chunk.total()[2] ) );
+  CHECK_THAT(   1., WithinRel( chunk.elastic()[0] ) );
+  CHECK_THAT(   2., WithinRel( chunk.elastic()[1] ) );
+  CHECK_THAT(   3., WithinRel( chunk.elastic()[2] ) );
+  CHECK_THAT(   4., WithinRel( chunk.bremsstrahlung()[0] ) );
+  CHECK_THAT(   5., WithinRel( chunk.bremsstrahlung()[1] ) );
+  CHECK_THAT(   6., WithinRel( chunk.bremsstrahlung()[2] ) );
+  CHECK_THAT(   7., WithinRel( chunk.excitation()[0] ) );
+  CHECK_THAT(   8., WithinRel( chunk.excitation()[1] ) );
+  CHECK_THAT(   9., WithinRel( chunk.excitation()[2] ) );
+  CHECK_THAT(  23., WithinRel( chunk.totalElectroionisation()[0] ) );
+  CHECK_THAT(  25., WithinRel( chunk.totalElectroionisation()[1] ) );
+  CHECK_THAT(  27., WithinRel( chunk.totalElectroionisation()[2] ) );
+  CHECK_THAT(  10., WithinRel( chunk.electroionisation(1)[0] ) );
+  CHECK_THAT(  11., WithinRel( chunk.electroionisation(1)[1] ) );
+  CHECK_THAT(  12., WithinRel( chunk.electroionisation(1)[2] ) );
+  CHECK_THAT(  13., WithinRel( chunk.electroionisation(2)[0] ) );
+  CHECK_THAT(  14., WithinRel( chunk.electroionisation(2)[1] ) );
+  CHECK_THAT(  15., WithinRel( chunk.electroionisation(2)[2] ) );
 }

--- a/src/ACEtk/electron/SubshellTransitionData/test/CMakeLists.txt
+++ b/src/ACEtk/electron/SubshellTransitionData/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.SubshellTransitionData.test SubshellTransitionData.test.cpp )
-target_compile_options( ACEtk.electron.SubshellTransitionData.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.SubshellTransitionData.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.SubshellTransitionData COMMAND ACEtk.electron.SubshellTransitionData.test )
+add_cpp_test( electron.SubshellTransitionData SubshellTransitionData.test.cpp )

--- a/src/ACEtk/electron/SubshellTransitionData/test/SubshellTransitionData.test.cpp
+++ b/src/ACEtk/electron/SubshellTransitionData/test/SubshellTransitionData.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/SubshellTransitionData.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -40,7 +44,7 @@ SCENARIO( "SubshellTransitionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +64,7 @@ SCENARIO( "SubshellTransitionData" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -88,31 +92,31 @@ void verifyChunk( const SubshellTransitionData& chunk ) {
   CHECK( 4 == chunk.transition(2).size() );
   CHECK( 4 == chunk.transition(3).size() );
 
-  CHECK(    1 == Approx( chunk.transition(1)[0] ) );
-  CHECK(    0 == Approx( chunk.transition(1)[1] ) );
-  CHECK(  3.5 == Approx( chunk.transition(1)[2] ) );
-  CHECK( 0.25 == Approx( chunk.transition(1)[3] ) );
-  CHECK(    2 == Approx( chunk.transition(2)[0] ) );
-  CHECK(    3 == Approx( chunk.transition(2)[1] ) );
-  CHECK(  2.5 == Approx( chunk.transition(2)[2] ) );
-  CHECK( 0.75 == Approx( chunk.transition(2)[3] ) );
-  CHECK(    3 == Approx( chunk.transition(3)[0] ) );
-  CHECK(    1 == Approx( chunk.transition(3)[1] ) );
-  CHECK(  5.5 == Approx( chunk.transition(3)[2] ) );
-  CHECK( 1.00 == Approx( chunk.transition(3)[3] ) );
+  CHECK_THAT(    1, WithinRel( chunk.transition(1)[0] ) );
+  CHECK_THAT(    0, WithinRel( chunk.transition(1)[1] ) );
+  CHECK_THAT(  3.5, WithinRel( chunk.transition(1)[2] ) );
+  CHECK_THAT( 0.25, WithinRel( chunk.transition(1)[3] ) );
+  CHECK_THAT(    2, WithinRel( chunk.transition(2)[0] ) );
+  CHECK_THAT(    3, WithinRel( chunk.transition(2)[1] ) );
+  CHECK_THAT(  2.5, WithinRel( chunk.transition(2)[2] ) );
+  CHECK_THAT( 0.75, WithinRel( chunk.transition(2)[3] ) );
+  CHECK_THAT(    3, WithinRel( chunk.transition(3)[0] ) );
+  CHECK_THAT(    1, WithinRel( chunk.transition(3)[1] ) );
+  CHECK_THAT(  5.5, WithinRel( chunk.transition(3)[2] ) );
+  CHECK_THAT( 1.00, WithinRel( chunk.transition(3)[3] ) );
 
   CHECK(    1 == chunk.primaryDesignator(1) );
   CHECK(    0 == chunk.secondaryDesignator(1) );
-  CHECK(  3.5 == Approx( chunk.energy(1) ) );
-  CHECK( 0.25 == Approx( chunk.probability(1) ) );
+  CHECK_THAT(  3.5, WithinRel( chunk.energy(1) ) );
+  CHECK_THAT( 0.25, WithinRel( chunk.probability(1) ) );
   CHECK(    2 == chunk.primaryDesignator(2) );
   CHECK(    3 == chunk.secondaryDesignator(2) );
-  CHECK(  2.5 == Approx( chunk.energy(2) ) );
-  CHECK( 0.75 == Approx( chunk.probability(2) ) );
+  CHECK_THAT(  2.5, WithinRel( chunk.energy(2) ) );
+  CHECK_THAT( 0.75, WithinRel( chunk.probability(2) ) );
   CHECK(    3 == chunk.primaryDesignator(3) );
   CHECK(    1 == chunk.secondaryDesignator(3) );
-  CHECK(  5.5 == Approx( chunk.energy(3) ) );
-  CHECK( 1.00 == Approx( chunk.probability(3) ) );
+  CHECK_THAT(  5.5, WithinRel( chunk.energy(3) ) );
+  CHECK_THAT( 1.00, WithinRel( chunk.probability(3) ) );
 
   CHECK( true == chunk.isRadiativeTransition(1) );
   CHECK( false == chunk.isRadiativeTransition(2) );

--- a/src/ACEtk/electron/SubshellTransitionData/test/SubshellTransitionData.test.cpp
+++ b/src/ACEtk/electron/SubshellTransitionData/test/SubshellTransitionData.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/SubshellTransitionData.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/SubshellTransitionDataBlock/test/CMakeLists.txt
+++ b/src/ACEtk/electron/SubshellTransitionDataBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.SubshellTransitionDataBlock.test SubshellTransitionDataBlock.test.cpp )
-target_compile_options( ACEtk.electron.SubshellTransitionDataBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.SubshellTransitionDataBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.SubshellTransitionDataBlock COMMAND ACEtk.electron.SubshellTransitionDataBlock.test )
+add_cpp_test( electron.SubshellTransitionDataBlock SubshellTransitionDataBlock.test.cpp )

--- a/src/ACEtk/electron/SubshellTransitionDataBlock/test/SubshellTransitionDataBlock.test.cpp
+++ b/src/ACEtk/electron/SubshellTransitionDataBlock/test/SubshellTransitionDataBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/SubshellTransitionDataBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -43,7 +47,7 @@ SCENARIO( "SubshellTransitionDataBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -63,7 +67,7 @@ SCENARIO( "SubshellTransitionDataBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -104,31 +108,31 @@ void verifyChunk( const SubshellTransitionDataBlock& chunk ) {
   CHECK( 4 == xs.transition(2).size() );
   CHECK( 4 == xs.transition(3).size() );
 
-  CHECK(    1 == Approx( xs.transition(1)[0] ) );
-  CHECK(    0 == Approx( xs.transition(1)[1] ) );
-  CHECK(  3.5 == Approx( xs.transition(1)[2] ) );
-  CHECK( 0.25 == Approx( xs.transition(1)[3] ) );
-  CHECK(    2 == Approx( xs.transition(2)[0] ) );
-  CHECK(    3 == Approx( xs.transition(2)[1] ) );
-  CHECK(  2.5 == Approx( xs.transition(2)[2] ) );
-  CHECK( 0.75 == Approx( xs.transition(2)[3] ) );
-  CHECK(    3 == Approx( xs.transition(3)[0] ) );
-  CHECK(    1 == Approx( xs.transition(3)[1] ) );
-  CHECK(  5.5 == Approx( xs.transition(3)[2] ) );
-  CHECK( 1.00 == Approx( xs.transition(3)[3] ) );
+  CHECK_THAT(    1, WithinRel( xs.transition(1)[0] ) );
+  CHECK_THAT(    0, WithinRel( xs.transition(1)[1] ) );
+  CHECK_THAT(  3.5, WithinRel( xs.transition(1)[2] ) );
+  CHECK_THAT( 0.25, WithinRel( xs.transition(1)[3] ) );
+  CHECK_THAT(    2, WithinRel( xs.transition(2)[0] ) );
+  CHECK_THAT(    3, WithinRel( xs.transition(2)[1] ) );
+  CHECK_THAT(  2.5, WithinRel( xs.transition(2)[2] ) );
+  CHECK_THAT( 0.75, WithinRel( xs.transition(2)[3] ) );
+  CHECK_THAT(    3, WithinRel( xs.transition(3)[0] ) );
+  CHECK_THAT(    1, WithinRel( xs.transition(3)[1] ) );
+  CHECK_THAT(  5.5, WithinRel( xs.transition(3)[2] ) );
+  CHECK_THAT( 1.00, WithinRel( xs.transition(3)[3] ) );
 
   CHECK(    1 == xs.primaryDesignator(1) );
   CHECK(    0 == xs.secondaryDesignator(1) );
-  CHECK(  3.5 == Approx( xs.energy(1) ) );
-  CHECK( 0.25 == Approx( xs.probability(1) ) );
+  CHECK_THAT(  3.5, WithinRel( xs.energy(1) ) );
+  CHECK_THAT( 0.25, WithinRel( xs.probability(1) ) );
   CHECK(    2 == xs.primaryDesignator(2) );
   CHECK(    3 == xs.secondaryDesignator(2) );
-  CHECK(  2.5 == Approx( xs.energy(2) ) );
-  CHECK( 0.75 == Approx( xs.probability(2) ) );
+  CHECK_THAT(  2.5, WithinRel( xs.energy(2) ) );
+  CHECK_THAT( 0.75, WithinRel( xs.probability(2) ) );
   CHECK(    3 == xs.primaryDesignator(3) );
   CHECK(    1 == xs.secondaryDesignator(3) );
-  CHECK(  5.5 == Approx( xs.energy(3) ) );
-  CHECK( 1.00 == Approx( xs.probability(3) ) );
+  CHECK_THAT(  5.5, WithinRel( xs.energy(3) ) );
+  CHECK_THAT( 1.00, WithinRel( xs.probability(3) ) );
 
   CHECK( true == xs.isRadiativeTransition(1) );
   CHECK( false == xs.isRadiativeTransition(2) );
@@ -153,31 +157,31 @@ void verifyChunk( const SubshellTransitionDataBlock& chunk ) {
   CHECK( 4 == xs.transition(2).size() );
   CHECK( 4 == xs.transition(3).size() );
 
-  CHECK(    1 == Approx( xs.transition(1)[0] ) );
-  CHECK(    0 == Approx( xs.transition(1)[1] ) );
-  CHECK(  3.5 == Approx( xs.transition(1)[2] ) );
-  CHECK( 0.25 == Approx( xs.transition(1)[3] ) );
-  CHECK(    2 == Approx( xs.transition(2)[0] ) );
-  CHECK(    3 == Approx( xs.transition(2)[1] ) );
-  CHECK(  2.5 == Approx( xs.transition(2)[2] ) );
-  CHECK( 0.75 == Approx( xs.transition(2)[3] ) );
-  CHECK(    3 == Approx( xs.transition(3)[0] ) );
-  CHECK(    1 == Approx( xs.transition(3)[1] ) );
-  CHECK(  5.5 == Approx( xs.transition(3)[2] ) );
-  CHECK( 1.00 == Approx( xs.transition(3)[3] ) );
+  CHECK_THAT(    1, WithinRel( xs.transition(1)[0] ) );
+  CHECK_THAT(    0, WithinRel( xs.transition(1)[1] ) );
+  CHECK_THAT(  3.5, WithinRel( xs.transition(1)[2] ) );
+  CHECK_THAT( 0.25, WithinRel( xs.transition(1)[3] ) );
+  CHECK_THAT(    2, WithinRel( xs.transition(2)[0] ) );
+  CHECK_THAT(    3, WithinRel( xs.transition(2)[1] ) );
+  CHECK_THAT(  2.5, WithinRel( xs.transition(2)[2] ) );
+  CHECK_THAT( 0.75, WithinRel( xs.transition(2)[3] ) );
+  CHECK_THAT(    3, WithinRel( xs.transition(3)[0] ) );
+  CHECK_THAT(    1, WithinRel( xs.transition(3)[1] ) );
+  CHECK_THAT(  5.5, WithinRel( xs.transition(3)[2] ) );
+  CHECK_THAT( 1.00, WithinRel( xs.transition(3)[3] ) );
 
   CHECK(    1 == xs.primaryDesignator(1) );
   CHECK(    0 == xs.secondaryDesignator(1) );
-  CHECK(  3.5 == Approx( xs.energy(1) ) );
-  CHECK( 0.25 == Approx( xs.probability(1) ) );
+  CHECK_THAT(  3.5, WithinRel( xs.energy(1) ) );
+  CHECK_THAT( 0.25, WithinRel( xs.probability(1) ) );
   CHECK(    2 == xs.primaryDesignator(2) );
   CHECK(    3 == xs.secondaryDesignator(2) );
-  CHECK(  2.5 == Approx( xs.energy(2) ) );
-  CHECK( 0.75 == Approx( xs.probability(2) ) );
+  CHECK_THAT(  2.5, WithinRel( xs.energy(2) ) );
+  CHECK_THAT( 0.75, WithinRel( xs.probability(2) ) );
   CHECK(    3 == xs.primaryDesignator(3) );
   CHECK(    1 == xs.secondaryDesignator(3) );
-  CHECK(  5.5 == Approx( xs.energy(3) ) );
-  CHECK( 1.00 == Approx( xs.probability(3) ) );
+  CHECK_THAT(  5.5, WithinRel( xs.energy(3) ) );
+  CHECK_THAT( 1.00, WithinRel( xs.probability(3) ) );
 
   CHECK( true == xs.isRadiativeTransition(1) );
   CHECK( false == xs.isRadiativeTransition(2) );

--- a/src/ACEtk/electron/SubshellTransitionDataBlock/test/SubshellTransitionDataBlock.test.cpp
+++ b/src/ACEtk/electron/SubshellTransitionDataBlock/test/SubshellTransitionDataBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/SubshellTransitionDataBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/TabulatedAngularDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/electron/TabulatedAngularDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.TabulatedAngularDistribution.test TabulatedAngularDistribution.test.cpp )
-target_compile_options( ACEtk.electron.TabulatedAngularDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.TabulatedAngularDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.TabulatedAngularDistribution COMMAND ACEtk.electron.TabulatedAngularDistribution.test )
+add_cpp_test( electron.TabulatedAngularDistribution TabulatedAngularDistribution.test.cpp )

--- a/src/ACEtk/electron/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
+++ b/src/ACEtk/electron/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/TabulatedAngularDistribution.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
+++ b/src/ACEtk/electron/TabulatedAngularDistribution/test/TabulatedAngularDistribution.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/TabulatedAngularDistribution.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -38,7 +42,7 @@ SCENARIO( "TabulatedAngularDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -58,7 +62,7 @@ SCENARIO( "TabulatedAngularDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -77,7 +81,7 @@ void verifyChunk( const TabulatedAngularDistribution& chunk ) {
   CHECK( 6 == chunk.length() );
   CHECK( "TabulatedAngularDistribution" == chunk.name() );
 
-  CHECK( 1000. == Approx( chunk.energy() ) );
+  CHECK_THAT( 1000., WithinRel( chunk.energy() ) );
 
   CHECK( 3 == chunk.LA() );
   CHECK( 3 == chunk.numberCosines() );
@@ -85,11 +89,11 @@ void verifyChunk( const TabulatedAngularDistribution& chunk ) {
   CHECK( 3 == chunk.cosines().size() );
   CHECK( 3 == chunk.cdf().size() );
 
-  CHECK( -1. == Approx( chunk.cosines()[0] ) );
-  CHECK(  0. == Approx( chunk.cosines()[1] ) );
-  CHECK(  1. == Approx( chunk.cosines()[2] ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines()[0] ) );
+  CHECK_THAT(  0., WithinRel( chunk.cosines()[1] ) );
+  CHECK_THAT(  1., WithinRel( chunk.cosines()[2] ) );
 
-  CHECK(  0.   == Approx( chunk.cdf()[0] ) );
-  CHECK(  0.75 == Approx( chunk.cdf()[1] ) );
-  CHECK(  1.   == Approx( chunk.cdf()[2] ) );
+  CHECK_THAT(  0.  , WithinRel( chunk.cdf()[0] ) );
+  CHECK_THAT(  0.75, WithinRel( chunk.cdf()[1] ) );
+  CHECK_THAT(  1.  , WithinRel( chunk.cdf()[2] ) );
 }

--- a/src/ACEtk/electron/TabulatedEnergyDistribution/test/CMakeLists.txt
+++ b/src/ACEtk/electron/TabulatedEnergyDistribution/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.electron.TabulatedEnergyDistribution.test TabulatedEnergyDistribution.test.cpp )
-target_compile_options( ACEtk.electron.TabulatedEnergyDistribution.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.electron.TabulatedEnergyDistribution.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.electron.TabulatedEnergyDistribution COMMAND ACEtk.electron.TabulatedEnergyDistribution.test )
+add_cpp_test( electron.TabulatedEnergyDistribution TabulatedEnergyDistribution.test.cpp )

--- a/src/ACEtk/electron/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
+++ b/src/ACEtk/electron/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/electron/TabulatedEnergyDistribution.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/electron/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
+++ b/src/ACEtk/electron/TabulatedEnergyDistribution/test/TabulatedEnergyDistribution.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/electron/TabulatedEnergyDistribution.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -38,7 +42,7 @@ SCENARIO( "TabulatedEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -58,7 +62,7 @@ SCENARIO( "TabulatedEnergyDistribution" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -77,7 +81,7 @@ void verifyChunk( const TabulatedEnergyDistribution& chunk ) {
   CHECK( 6 == chunk.length() );
   CHECK( "TabulatedEnergyDistribution" == chunk.name() );
 
-  CHECK( 1000. == Approx( chunk.energy() ) );
+  CHECK_THAT( 1000., WithinRel( chunk.energy() ) );
 
   CHECK( 3 == chunk.LB() );
   CHECK( 3 == chunk.numberOutgoingEnergies() );
@@ -85,11 +89,11 @@ void verifyChunk( const TabulatedEnergyDistribution& chunk ) {
   CHECK( 3 == chunk.outgoingEnergies().size() );
   CHECK( 3 == chunk.cdf().size() );
 
-  CHECK(  10. == Approx( chunk.outgoingEnergies()[0] ) );
-  CHECK( 100. == Approx( chunk.outgoingEnergies()[1] ) );
-  CHECK( 999. == Approx( chunk.outgoingEnergies()[2] ) );
+  CHECK_THAT(  10., WithinRel( chunk.outgoingEnergies()[0] ) );
+  CHECK_THAT( 100., WithinRel( chunk.outgoingEnergies()[1] ) );
+  CHECK_THAT( 999., WithinRel( chunk.outgoingEnergies()[2] ) );
 
-  CHECK(  0.   == Approx( chunk.cdf()[0] ) );
-  CHECK(  0.75 == Approx( chunk.cdf()[1] ) );
-  CHECK(  1.   == Approx( chunk.cdf()[2] ) );
+  CHECK_THAT(  0.  , WithinRel( chunk.cdf()[0] ) );
+  CHECK_THAT(  0.75, WithinRel( chunk.cdf()[1] ) );
+  CHECK_THAT(  1.  , WithinRel( chunk.cdf()[2] ) );
 }

--- a/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.CoherentFormFactorBlock.test CoherentFormFactorBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.CoherentFormFactorBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.CoherentFormFactorBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.CoherentFormFactorBlock COMMAND ACEtk.photoatomic.CoherentFormFactorBlock.test )
+add_cpp_test( photoatomic.CoherentFormFactorBlock CoherentFormFactorBlock.test.cpp )

--- a/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
+++ b/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/CoherentFormFactorBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -71,7 +75,7 @@ SCENARIO( "CoherentFormFactorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -91,7 +95,7 @@ SCENARIO( "CoherentFormFactorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -122,7 +126,7 @@ SCENARIO( "CoherentFormFactorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -142,7 +146,7 @@ SCENARIO( "CoherentFormFactorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -204,16 +208,16 @@ void verifyChunk( const CoherentFormFactorBlock& chunk ) {
   CHECK( 55 == chunk.numberValues() );
 
   CHECK( 55 == chunk.momentum().size() );
-  CHECK( 0.   == Approx( chunk.momentum().front() ) );
-  CHECK( 6.   == Approx( chunk.momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.momentum().front() ) );
+  CHECK_THAT( 6.  , WithinRel( chunk.momentum().back() ) );
 
   CHECK( 55 == chunk.integratedFormFactors().size() );
-  CHECK( 0. == Approx( chunk.integratedFormFactors()[0] ) );
-  CHECK( 3.058316405266E-02 == Approx( chunk.integratedFormFactors().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.integratedFormFactors()[0] ) );
+  CHECK_THAT( 3.058316405266E-02, WithinRel( chunk.integratedFormFactors().back() ) );
 
   CHECK( 55 == chunk.formFactors().size() );
-  CHECK( 1. == Approx( chunk.formFactors()[0] ) );
-  CHECK( 6.282390000000E-06 == Approx( chunk.formFactors().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.formFactors()[0] ) );
+  CHECK_THAT( 6.282390000000E-06, WithinRel( chunk.formFactors().back() ) );
 }
 
 void verifyChunkEprdata( const CoherentFormFactorBlock& chunk ) {
@@ -226,14 +230,14 @@ void verifyChunkEprdata( const CoherentFormFactorBlock& chunk ) {
   CHECK( 5 == chunk.numberValues() );
 
   CHECK( 5 == chunk.momentum().size() );
-  CHECK( 0.   == Approx( chunk.momentum().front() ) );
-  CHECK( 1e+9 == Approx( chunk.momentum().back() ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.momentum().front() ) );
+  CHECK_THAT( 1e+9, WithinRel( chunk.momentum().back() ) );
 
   CHECK( 5 == chunk.integratedFormFactors().size() );
-  CHECK( 1. == Approx( chunk.integratedFormFactors().front() ) );
-  CHECK( 5. == Approx( chunk.integratedFormFactors().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.integratedFormFactors().front() ) );
+  CHECK_THAT( 5., WithinRel( chunk.integratedFormFactors().back() ) );
 
   CHECK( 5 == chunk.formFactors().size() );
-  CHECK(  6. == Approx( chunk.formFactors().front() ) );
-  CHECK( 10. == Approx( chunk.formFactors().back() ) );
+  CHECK_THAT(  6., WithinRel( chunk.formFactors().front() ) );
+  CHECK_THAT( 10., WithinRel( chunk.formFactors().back() ) );
 }

--- a/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
+++ b/src/ACEtk/photoatomic/CoherentFormFactorBlock/test/CoherentFormFactorBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/CoherentFormFactorBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/ComptonProfile/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/ComptonProfile/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.ComptonProfile.test ComptonProfile.test.cpp )
-target_compile_options( ACEtk.photoatomic.ComptonProfile.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.ComptonProfile.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.ComptonProfile COMMAND ACEtk.photoatomic.ComptonProfile.test )
+add_cpp_test( photoatomic.ComptonProfile ComptonProfile.test.cpp )

--- a/src/ACEtk/photoatomic/ComptonProfile/test/ComptonProfile.test.cpp
+++ b/src/ACEtk/photoatomic/ComptonProfile/test/ComptonProfile.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/ComptonProfile.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/ComptonProfile/test/ComptonProfile.test.cpp
+++ b/src/ACEtk/photoatomic/ComptonProfile/test/ComptonProfile.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/ComptonProfile.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +45,7 @@ SCENARIO( "ComptonProfile" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -61,7 +65,7 @@ SCENARIO( "ComptonProfile" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -85,14 +89,14 @@ void verifyChunk( const ComptonProfile& chunk ) {
   CHECK( 3 == chunk.numberValues() );
 
   CHECK( 3 == chunk.momentum().size() );
-  CHECK( 1e-11 == Approx( chunk.momentum().front() ) );
-  CHECK( 20. == Approx( chunk.momentum().back() ) );
+  CHECK_THAT( 1e-11, WithinRel( chunk.momentum().front() ) );
+  CHECK_THAT( 20., WithinRel( chunk.momentum().back() ) );
 
   CHECK( 3 == chunk.pdf().size() );
-  CHECK( .5 == Approx( chunk.pdf().front() ) );
-  CHECK( .5 == Approx( chunk.pdf().back() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().front() ) );
+  CHECK_THAT( .5, WithinRel( chunk.pdf().back() ) );
 
   CHECK( 3 == chunk.cdf().size() );
-  CHECK( 0. == Approx( chunk.cdf().front() ) );
-  CHECK( 1. == Approx( chunk.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( chunk.cdf().back() ) );
 }

--- a/src/ACEtk/photoatomic/ComptonProfileBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/ComptonProfileBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.ComptonProfileBlock.test ComptonProfileBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.ComptonProfileBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.ComptonProfileBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.block.ComptonProfileBlock COMMAND ACEtk.photoatomic.ComptonProfileBlock.test )
+add_cpp_test( photoatomic.ComptonProfileBlock ComptonProfileBlock.test.cpp )

--- a/src/ACEtk/photoatomic/ComptonProfileBlock/test/ComptonProfileBlock.test.cpp
+++ b/src/ACEtk/photoatomic/ComptonProfileBlock/test/ComptonProfileBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/ComptonProfileBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -91,7 +95,7 @@ SCENARIO( "ComptonProfileBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -110,7 +114,7 @@ SCENARIO( "ComptonProfileBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -192,51 +196,51 @@ void verifyChunk( const ComptonProfileBlock& chunk ) {
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 6.527863344596e-01 == Approx( profile.pdf().front() ) );
-  CHECK( 3.571475386101e-10 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 6.527863344596e-01, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 3.571475386101e-10, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   profile = chunk.comptonProfile(2);
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 3.848272047027e+00 == Approx( profile.pdf().front() ) );
-  CHECK( 8.728039694288e-12 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 3.848272047027e+00, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 8.728039694288e-12, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   profile = chunk.data()[0];
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 6.527863344596e-01 == Approx( profile.pdf().front() ) );
-  CHECK( 3.571475386101e-10 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 6.527863344596e-01, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 3.571475386101e-10, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 
   profile = chunk.data()[1];
   CHECK( 2 == profile.interpolation() );
   CHECK( 31 == profile.numberValues() );
   CHECK( 31 == profile.momentum().size() );
-  CHECK( 0. == Approx( profile.momentum().front() ) );
-  CHECK( 100. == Approx( profile.momentum().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.momentum().front() ) );
+  CHECK_THAT( 100., WithinRel( profile.momentum().back() ) );
   CHECK( 31 == profile.pdf().size() );
-  CHECK( 3.848272047027e+00 == Approx( profile.pdf().front() ) );
-  CHECK( 8.728039694288e-12 == Approx( profile.pdf().back() ) );
+  CHECK_THAT( 3.848272047027e+00, WithinRel( profile.pdf().front() ) );
+  CHECK_THAT( 8.728039694288e-12, WithinRel( profile.pdf().back() ) );
   CHECK( 31 == profile.cdf().size() );
-  CHECK( 0. == Approx( profile.cdf().front() ) );
-  CHECK( 1. == Approx( profile.cdf().back() ) );
+  CHECK_THAT( 0., WithinRel( profile.cdf().front() ) );
+  CHECK_THAT( 1., WithinRel( profile.cdf().back() ) );
 }

--- a/src/ACEtk/photoatomic/ComptonProfileBlock/test/ComptonProfileBlock.test.cpp
+++ b/src/ACEtk/photoatomic/ComptonProfileBlock/test/ComptonProfileBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/ComptonProfileBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/FluorescenceDataBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/FluorescenceDataBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.FluorescenceDataBlock.test FluorescenceDataBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.FluorescenceDataBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.FluorescenceDataBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.FluorescenceDataBlock COMMAND ACEtk.photoatomic.FluorescenceDataBlock.test )
+add_cpp_test( photoatomic.FluorescenceDataBlock FluorescenceDataBlock.test.cpp )

--- a/src/ACEtk/photoatomic/FluorescenceDataBlock/test/FluorescenceDataBlock.test.cpp
+++ b/src/ACEtk/photoatomic/FluorescenceDataBlock/test/FluorescenceDataBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/FluorescenceDataBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/FluorescenceDataBlock/test/FluorescenceDataBlock.test.cpp
+++ b/src/ACEtk/photoatomic/FluorescenceDataBlock/test/FluorescenceDataBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/FluorescenceDataBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -41,7 +45,7 @@ SCENARIO( "FluorescenceDataBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -61,7 +65,7 @@ SCENARIO( "FluorescenceDataBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,20 +99,20 @@ void verifyChunk( const FluorescenceDataBlock& chunk ) {
   CHECK( 2 == chunk.yields().size() );
   CHECK( 2 == chunk.fluorescentEnergies().size() );
 
-  CHECK( 1.294500000000E-03 == Approx( chunk.E().front() ) );
-  CHECK( 1.294500000000E-03 == Approx( chunk.E().back() ) );
-  CHECK( 8.180862310960E-02 == Approx( chunk.PHI().front() ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.PHI().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.Y().front() ) );
-  CHECK( 2.542671170140E-02 == Approx( chunk.Y().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.F().front() ) );
-  CHECK( 1.238156190380E-03 == Approx( chunk.F().back() ) );
-  CHECK( 1.294500000000E-03 == Approx( chunk.fluorescenceEdgeEnergies().front() ) );
-  CHECK( 1.294500000000E-03 == Approx( chunk.fluorescenceEdgeEnergies().back() ) );
-  CHECK( 8.180862310960E-02 == Approx( chunk.relativeEjectionProbabilities().front() ) );
-  CHECK( 1.000000000000E+00 == Approx( chunk.relativeEjectionProbabilities().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.yields().front() ) );
-  CHECK( 2.542671170140E-02 == Approx( chunk.yields().back() ) );
-  CHECK( 0.000000000000E+00 == Approx( chunk.fluorescentEnergies().front() ) );
-  CHECK( 1.238156190380E-03 == Approx( chunk.fluorescentEnergies().back() ) );
+  CHECK_THAT( 1.294500000000E-03, WithinRel( chunk.E().front() ) );
+  CHECK_THAT( 1.294500000000E-03, WithinRel( chunk.E().back() ) );
+  CHECK_THAT( 8.180862310960E-02, WithinRel( chunk.PHI().front() ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.PHI().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.Y().front() ) );
+  CHECK_THAT( 2.542671170140E-02, WithinRel( chunk.Y().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.F().front() ) );
+  CHECK_THAT( 1.238156190380E-03, WithinRel( chunk.F().back() ) );
+  CHECK_THAT( 1.294500000000E-03, WithinRel( chunk.fluorescenceEdgeEnergies().front() ) );
+  CHECK_THAT( 1.294500000000E-03, WithinRel( chunk.fluorescenceEdgeEnergies().back() ) );
+  CHECK_THAT( 8.180862310960E-02, WithinRel( chunk.relativeEjectionProbabilities().front() ) );
+  CHECK_THAT( 1.000000000000E+00, WithinRel( chunk.relativeEjectionProbabilities().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.yields().front() ) );
+  CHECK_THAT( 2.542671170140E-02, WithinRel( chunk.yields().back() ) );
+  CHECK_THAT( 0.000000000000E+00, WithinRel( chunk.fluorescentEnergies().front() ) );
+  CHECK_THAT( 1.238156190380E-03, WithinRel( chunk.fluorescentEnergies().back() ) );
 }

--- a/src/ACEtk/photoatomic/HeatingNumbersBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/HeatingNumbersBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.HeatingNumbersBlock.test HeatingNumbersBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.HeatingNumbersBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.HeatingNumbersBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.HeatingNumbersBlock COMMAND ACEtk.photoatomic.HeatingNumbersBlock.test )
+add_cpp_test( photoatomic.HeatingNumbersBlock HeatingNumbersBlock.test.cpp )

--- a/src/ACEtk/photoatomic/HeatingNumbersBlock/test/HeatingNumbersBlock.test.cpp
+++ b/src/ACEtk/photoatomic/HeatingNumbersBlock/test/HeatingNumbersBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/HeatingNumbersBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/HeatingNumbersBlock/test/HeatingNumbersBlock.test.cpp
+++ b/src/ACEtk/photoatomic/HeatingNumbersBlock/test/HeatingNumbersBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/HeatingNumbersBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -49,7 +53,7 @@ SCENARIO( "HeatingNumbersBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -69,7 +73,7 @@ SCENARIO( "HeatingNumbersBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -107,6 +111,6 @@ void verifyChunk( const HeatingNumbersBlock& chunk ) {
   CHECK( 43 == chunk.numberEnergyPoints() );
   CHECK( 43 == chunk.heating().size() );
 
-  CHECK( 9.457315870945E-04 == Approx( chunk.heating().front() ) );
-  CHECK( 9.086036433693E+01 == Approx( chunk.heating().back() ) );
+  CHECK_THAT( 9.457315870945E-04, WithinRel( chunk.heating().front() ) );
+  CHECK_THAT( 9.086036433693E+01, WithinRel( chunk.heating().back() ) );
 }

--- a/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.IncoherentScatteringFunctionBlock.test IncoherentScatteringFunctionBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.IncoherentScatteringFunctionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.IncoherentScatteringFunctionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.IncoherentScatteringFunctionBlock COMMAND ACEtk.photoatomic.IncoherentScatteringFunctionBlock.test )
+add_cpp_test( photoatomic.IncoherentScatteringFunctionBlock IncoherentScatteringFunctionBlock.test.cpp )

--- a/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/IncoherentScatteringFunctionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/IncoherentScatteringFunctionBlock/test/IncoherentScatteringFunctionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/IncoherentScatteringFunctionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -45,7 +49,7 @@ SCENARIO( "IncoherentScatteringFunctionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -65,7 +69,7 @@ SCENARIO( "IncoherentScatteringFunctionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -94,7 +98,7 @@ SCENARIO( "IncoherentScatteringFunctionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -114,7 +118,7 @@ SCENARIO( "IncoherentScatteringFunctionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -152,50 +156,50 @@ void verifyChunk( const IncoherentScatteringFunctionBlock& chunk ) {
   CHECK( 21 == chunk.numberValues() );
 
   CHECK( 21 == chunk.momentum().size() );
-  CHECK( 0.   == Approx( chunk.momentum()[0] ) );
-  CHECK( .005 == Approx( chunk.momentum()[1] ) );
-  CHECK( .01  == Approx( chunk.momentum()[2] ) );
-  CHECK( .05  == Approx( chunk.momentum()[3] ) );
-  CHECK( .1   == Approx( chunk.momentum()[4] ) );
-  CHECK( .15  == Approx( chunk.momentum()[5] ) );
-  CHECK( .2   == Approx( chunk.momentum()[6] ) );
-  CHECK( .3   == Approx( chunk.momentum()[7] ) );
-  CHECK( .4   == Approx( chunk.momentum()[8] ) );
-  CHECK( .5   == Approx( chunk.momentum()[9] ) );
-  CHECK( .6   == Approx( chunk.momentum()[10] ) );
-  CHECK( .7   == Approx( chunk.momentum()[11] ) );
-  CHECK( .8   == Approx( chunk.momentum()[12] ) );
-  CHECK( .9   == Approx( chunk.momentum()[13] ) );
-  CHECK( 1.   == Approx( chunk.momentum()[14] ) );
-  CHECK( 1.5  == Approx( chunk.momentum()[15] ) );
-  CHECK( 2.   == Approx( chunk.momentum()[16] ) );
-  CHECK( 3.   == Approx( chunk.momentum()[17] ) );
-  CHECK( 4.   == Approx( chunk.momentum()[18] ) );
-  CHECK( 5.   == Approx( chunk.momentum()[19] ) );
-  CHECK( 8.   == Approx( chunk.momentum()[20] ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.momentum()[0] ) );
+  CHECK_THAT( .005, WithinRel( chunk.momentum()[1] ) );
+  CHECK_THAT( .01 , WithinRel( chunk.momentum()[2] ) );
+  CHECK_THAT( .05 , WithinRel( chunk.momentum()[3] ) );
+  CHECK_THAT( .1  , WithinRel( chunk.momentum()[4] ) );
+  CHECK_THAT( .15 , WithinRel( chunk.momentum()[5] ) );
+  CHECK_THAT( .2  , WithinRel( chunk.momentum()[6] ) );
+  CHECK_THAT( .3  , WithinRel( chunk.momentum()[7] ) );
+  CHECK_THAT( .4  , WithinRel( chunk.momentum()[8] ) );
+  CHECK_THAT( .5  , WithinRel( chunk.momentum()[9] ) );
+  CHECK_THAT( .6  , WithinRel( chunk.momentum()[10] ) );
+  CHECK_THAT( .7  , WithinRel( chunk.momentum()[11] ) );
+  CHECK_THAT( .8  , WithinRel( chunk.momentum()[12] ) );
+  CHECK_THAT( .9  , WithinRel( chunk.momentum()[13] ) );
+  CHECK_THAT( 1.  , WithinRel( chunk.momentum()[14] ) );
+  CHECK_THAT( 1.5 , WithinRel( chunk.momentum()[15] ) );
+  CHECK_THAT( 2.  , WithinRel( chunk.momentum()[16] ) );
+  CHECK_THAT( 3.  , WithinRel( chunk.momentum()[17] ) );
+  CHECK_THAT( 4.  , WithinRel( chunk.momentum()[18] ) );
+  CHECK_THAT( 5.  , WithinRel( chunk.momentum()[19] ) );
+  CHECK_THAT( 8.  , WithinRel( chunk.momentum()[20] ) );
 
   CHECK( 21 == chunk.values().size() );
-  CHECK( 0 == Approx( chunk.values()[0] ) );
-  CHECK( 1.104680000000E-03 == Approx( chunk.values()[1] ) );
-  CHECK( 4.409660000000E-03 == Approx( chunk.values()[2] ) );
-  CHECK( 1.033110000000E-01 == Approx( chunk.values()[3] ) );
-  CHECK( 3.425650000000E-01 == Approx( chunk.values()[4] ) );
-  CHECK( 5.887310000000E-01 == Approx( chunk.values()[5] ) );
-  CHECK( 7.688390000000E-01 == Approx( chunk.values()[6] ) );
-  CHECK( 9.368610000000E-01 == Approx( chunk.values()[7] ) );
-  CHECK( 9.829840000000E-01 == Approx( chunk.values()[8] ) );
-  CHECK( 9.950160000000E-01 == Approx( chunk.values()[9] ) );
-  CHECK( 9.983740000000E-01 == Approx( chunk.values()[10] ) );
-  CHECK( 9.994100000000E-01 == Approx( chunk.values()[11] ) );
-  CHECK( 9.997650000000E-01 == Approx( chunk.values()[12] ) );
-  CHECK( 9.998980000000E-01 == Approx( chunk.values()[13] ) );
-  CHECK( 9.999530000000E-01 == Approx( chunk.values()[14] ) );
-  CHECK( 9.999980000000E-01 == Approx( chunk.values()[15] ) );
-  CHECK( 1 == Approx( chunk.values()[16] ) );
-  CHECK( 1 == Approx( chunk.values()[17] ) );
-  CHECK( 1 == Approx( chunk.values()[18] ) );
-  CHECK( 1 == Approx( chunk.values()[19] ) );
-  CHECK( 1 == Approx( chunk.values()[20] ) );
+  CHECK_THAT( 0, WithinRel( chunk.values()[0] ) );
+  CHECK_THAT( 1.104680000000E-03, WithinRel( chunk.values()[1] ) );
+  CHECK_THAT( 4.409660000000E-03, WithinRel( chunk.values()[2] ) );
+  CHECK_THAT( 1.033110000000E-01, WithinRel( chunk.values()[3] ) );
+  CHECK_THAT( 3.425650000000E-01, WithinRel( chunk.values()[4] ) );
+  CHECK_THAT( 5.887310000000E-01, WithinRel( chunk.values()[5] ) );
+  CHECK_THAT( 7.688390000000E-01, WithinRel( chunk.values()[6] ) );
+  CHECK_THAT( 9.368610000000E-01, WithinRel( chunk.values()[7] ) );
+  CHECK_THAT( 9.829840000000E-01, WithinRel( chunk.values()[8] ) );
+  CHECK_THAT( 9.950160000000E-01, WithinRel( chunk.values()[9] ) );
+  CHECK_THAT( 9.983740000000E-01, WithinRel( chunk.values()[10] ) );
+  CHECK_THAT( 9.994100000000E-01, WithinRel( chunk.values()[11] ) );
+  CHECK_THAT( 9.997650000000E-01, WithinRel( chunk.values()[12] ) );
+  CHECK_THAT( 9.998980000000E-01, WithinRel( chunk.values()[13] ) );
+  CHECK_THAT( 9.999530000000E-01, WithinRel( chunk.values()[14] ) );
+  CHECK_THAT( 9.999980000000E-01, WithinRel( chunk.values()[15] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[16] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[17] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[18] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[19] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[20] ) );
 }
 
 void verifyChunkEprdata( const IncoherentScatteringFunctionBlock& chunk ) {
@@ -208,16 +212,16 @@ void verifyChunkEprdata( const IncoherentScatteringFunctionBlock& chunk ) {
   CHECK( 5 == chunk.numberValues() );
 
   CHECK( 5 == chunk.momentum().size() );
-  CHECK( 0.   == Approx( chunk.momentum()[0] ) );
-  CHECK( 1.   == Approx( chunk.momentum()[1] ) );
-  CHECK( 1e+3 == Approx( chunk.momentum()[2] ) );
-  CHECK( 1e+6 == Approx( chunk.momentum()[3] ) );
-  CHECK( 1e+9 == Approx( chunk.momentum()[4] ) );
+  CHECK_THAT( 0.  , WithinRel( chunk.momentum()[0] ) );
+  CHECK_THAT( 1.  , WithinRel( chunk.momentum()[1] ) );
+  CHECK_THAT( 1e+3, WithinRel( chunk.momentum()[2] ) );
+  CHECK_THAT( 1e+6, WithinRel( chunk.momentum()[3] ) );
+  CHECK_THAT( 1e+9, WithinRel( chunk.momentum()[4] ) );
 
   CHECK( 5 == chunk.values().size() );
-  CHECK( 1 == Approx( chunk.values()[0] ) );
-  CHECK( 2. == Approx( chunk.values()[1] ) );
-  CHECK( 3. == Approx( chunk.values()[2] ) );
-  CHECK( 4. == Approx( chunk.values()[3] ) );
-  CHECK( 5. == Approx( chunk.values()[4] ) );
+  CHECK_THAT( 1, WithinRel( chunk.values()[0] ) );
+  CHECK_THAT( 2., WithinRel( chunk.values()[1] ) );
+  CHECK_THAT( 3., WithinRel( chunk.values()[2] ) );
+  CHECK_THAT( 4., WithinRel( chunk.values()[3] ) );
+  CHECK_THAT( 5., WithinRel( chunk.values()[4] ) );
 }

--- a/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.PhotoelectricCrossSectionBlock.test PhotoelectricCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.PhotoelectricCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.PhotoelectricCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.PhotoelectricCrossSectionBlock COMMAND ACEtk.photoatomic.PhotoelectricCrossSectionBlock.test )
+add_cpp_test( photoatomic.PhotoelectricCrossSectionBlock PhotoelectricCrossSectionBlock.test.cpp )

--- a/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/PhotoelectricCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/PhotoelectricCrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/PhotoelectricCrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/PhotoelectricCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/PhotoelectricCrossSectionBlock/test/PhotoelectricCrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/PhotoelectricCrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -40,7 +44,7 @@ SCENARIO( "PhotoelectricCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +64,7 @@ SCENARIO( "PhotoelectricCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -94,19 +98,19 @@ void verifyChunk( const PhotoelectricCrossSectionBlock& chunk ) {
   CHECK( 5 == chunk.photoelectric(2).size() );
   CHECK( 5 == chunk.photoelectric(3).size() );
 
-  CHECK(   1. == Approx( chunk.photoelectric(1)[0] ) );
-  CHECK(   2. == Approx( chunk.photoelectric(1)[1] ) );
-  CHECK(   3. == Approx( chunk.photoelectric(1)[2] ) );
-  CHECK(   4. == Approx( chunk.photoelectric(1)[3] ) );
-  CHECK(   5. == Approx( chunk.photoelectric(1)[4] ) );
-  CHECK(   6. == Approx( chunk.photoelectric(2)[0] ) );
-  CHECK(   7. == Approx( chunk.photoelectric(2)[1] ) );
-  CHECK(   8. == Approx( chunk.photoelectric(2)[2] ) );
-  CHECK(   9. == Approx( chunk.photoelectric(2)[3] ) );
-  CHECK(  10. == Approx( chunk.photoelectric(2)[4] ) );
-  CHECK(  11. == Approx( chunk.photoelectric(3)[0] ) );
-  CHECK(  12. == Approx( chunk.photoelectric(3)[1] ) );
-  CHECK(  13. == Approx( chunk.photoelectric(3)[2] ) );
-  CHECK(  14. == Approx( chunk.photoelectric(3)[3] ) );
-  CHECK(  15. == Approx( chunk.photoelectric(3)[4] ) );
+  CHECK_THAT(   1., WithinRel( chunk.photoelectric(1)[0] ) );
+  CHECK_THAT(   2., WithinRel( chunk.photoelectric(1)[1] ) );
+  CHECK_THAT(   3., WithinRel( chunk.photoelectric(1)[2] ) );
+  CHECK_THAT(   4., WithinRel( chunk.photoelectric(1)[3] ) );
+  CHECK_THAT(   5., WithinRel( chunk.photoelectric(1)[4] ) );
+  CHECK_THAT(   6., WithinRel( chunk.photoelectric(2)[0] ) );
+  CHECK_THAT(   7., WithinRel( chunk.photoelectric(2)[1] ) );
+  CHECK_THAT(   8., WithinRel( chunk.photoelectric(2)[2] ) );
+  CHECK_THAT(   9., WithinRel( chunk.photoelectric(2)[3] ) );
+  CHECK_THAT(  10., WithinRel( chunk.photoelectric(2)[4] ) );
+  CHECK_THAT(  11., WithinRel( chunk.photoelectric(3)[0] ) );
+  CHECK_THAT(  12., WithinRel( chunk.photoelectric(3)[1] ) );
+  CHECK_THAT(  13., WithinRel( chunk.photoelectric(3)[2] ) );
+  CHECK_THAT(  14., WithinRel( chunk.photoelectric(3)[3] ) );
+  CHECK_THAT(  15., WithinRel( chunk.photoelectric(3)[4] ) );
 }

--- a/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photoatomic.PrincipalCrossSectionBlock.test PrincipalCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.photoatomic.PrincipalCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photoatomic.PrincipalCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photoatomic.PrincipalCrossSectionBlock COMMAND ACEtk.photoatomic.PrincipalCrossSectionBlock.test )
+add_cpp_test( photoatomic.PrincipalCrossSectionBlock PrincipalCrossSectionBlock.test.cpp )

--- a/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photoatomic/PrincipalCrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photoatomic/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photoatomic/PrincipalCrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -110,7 +114,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -130,7 +134,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -214,14 +218,14 @@ void verifyChunk( const PrincipalCrossSectionBlock& chunk ) {
   CHECK( 43 == chunk.photoelectric().size() );
   CHECK( 43 == chunk.pairproduction().size() );
 
-  CHECK( -6.907755278982E+00 == Approx( chunk.energies().front() ) );
-  CHECK(  4.605170185988E+00 == Approx( chunk.energies().back() ) );
-  CHECK( -2.474115088710E+00 == Approx( chunk.incoherent().front() ) );
-  CHECK( -4.794460770140E+00 == Approx( chunk.incoherent().back() ) );
-  CHECK( -5.438809818403E-01 == Approx( chunk.coherent().front() ) );
-  CHECK( -2.149558177385E+01 == Approx( chunk.coherent().back() ) );
-  CHECK(  2.449279472145E+00 == Approx( chunk.photoelectric().front() ) );
-  CHECK( -2.622629761934E+01 == Approx( chunk.photoelectric().back() ) );
-  CHECK(  0.000000000000E+00 == Approx( chunk.pairproduction().front() ) );
-  CHECK( -4.455371820900E+00 == Approx( chunk.pairproduction().back() ) );
+  CHECK_THAT( -6.907755278982E+00, WithinRel( chunk.energies().front() ) );
+  CHECK_THAT(  4.605170185988E+00, WithinRel( chunk.energies().back() ) );
+  CHECK_THAT( -2.474115088710E+00, WithinRel( chunk.incoherent().front() ) );
+  CHECK_THAT( -4.794460770140E+00, WithinRel( chunk.incoherent().back() ) );
+  CHECK_THAT( -5.438809818403E-01, WithinRel( chunk.coherent().front() ) );
+  CHECK_THAT( -2.149558177385E+01, WithinRel( chunk.coherent().back() ) );
+  CHECK_THAT(  2.449279472145E+00, WithinRel( chunk.photoelectric().front() ) );
+  CHECK_THAT( -2.622629761934E+01, WithinRel( chunk.photoelectric().back() ) );
+  CHECK_THAT(  0.000000000000E+00, WithinRel( chunk.pairproduction().front() ) );
+  CHECK_THAT( -4.455371820900E+00, WithinRel( chunk.pairproduction().back() ) );
 }

--- a/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photonuclear.PrincipalCrossSectionBlock.test PrincipalCrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.photonuclear.PrincipalCrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photonuclear.PrincipalCrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photonuclear.PrincipalCrossSectionBlock COMMAND ACEtk.photonuclear.PrincipalCrossSectionBlock.test )
+add_cpp_test( photonuclear.PrincipalCrossSectionBlock PrincipalCrossSectionBlock.test.cpp )

--- a/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photonuclear/PrincipalCrossSectionBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
+++ b/src/ACEtk/photonuclear/PrincipalCrossSectionBlock/test/PrincipalCrossSectionBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photonuclear/PrincipalCrossSectionBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -114,7 +118,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -134,7 +138,7 @@ SCENARIO( "PrincipalCrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -231,10 +235,10 @@ void verifyChunk( const PrincipalCrossSectionBlock& chunk ) {
   CHECK( 90 == chunk.heating().size() );
   CHECK( 0 == chunk.elastic().size() );
 
-  CHECK( 1. == Approx( chunk.energies().front() ) );
-  CHECK( 200. == Approx( chunk.energies().back() ) );
-  CHECK( 0. == Approx( chunk.total().front() ) );
-  CHECK( 6.99225100000E-03 == Approx( chunk.total().back() ) );
-  CHECK( 0. == Approx( chunk.heating().front() ) );
-  CHECK( 309.8838 == Approx( chunk.heating().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.energies().front() ) );
+  CHECK_THAT( 200., WithinRel( chunk.energies().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.total().front() ) );
+  CHECK_THAT( 6.99225100000E-03, WithinRel( chunk.total().back() ) );
+  CHECK_THAT( 0., WithinRel( chunk.heating().front() ) );
+  CHECK_THAT( 309.8838, WithinRel( chunk.heating().back() ) );
 }

--- a/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/CMakeLists.txt
+++ b/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.photonuclear.SecondaryParticleLocatorBlock.test SecondaryParticleLocatorBlock.test.cpp )
-target_compile_options( ACEtk.photonuclear.SecondaryParticleLocatorBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.photonuclear.SecondaryParticleLocatorBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.photonuclear.SecondaryParticleLocatorBlock COMMAND ACEtk.photonuclear.SecondaryParticleLocatorBlock.test )
+add_cpp_test( photonuclear.SecondaryParticleLocatorBlock SecondaryParticleLocatorBlock.test.cpp )

--- a/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
+++ b/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
@@ -1,9 +1,13 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/photonuclear/SecondaryParticleLocatorBlock.hpp"
 
 // other includes
+#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;
@@ -68,7 +72,7 @@ SCENARIO( "SecondaryParticleLocatorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -88,7 +92,7 @@ SCENARIO( "SecondaryParticleLocatorBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN

--- a/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
+++ b/src/ACEtk/photonuclear/SecondaryParticleLocatorBlock/test/SecondaryParticleLocatorBlock.test.cpp
@@ -7,7 +7,6 @@ using Catch::Matchers::WithinRel;
 #include "ACEtk/photonuclear/SecondaryParticleLocatorBlock.hpp"
 
 // other includes
-#include "ACEtk/fromFile.hpp"
 
 // convenience typedefs
 using namespace njoy::ACEtk;

--- a/src/ACEtk/thermal/CrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/CrossSectionBlock/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_cpp_test( CrossSectionBlock CrossSectionBlock.test.cpp )
+add_cpp_test( thermal.CrossSectionBlock CrossSectionBlock.test.cpp )

--- a/src/ACEtk/thermal/CrossSectionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/CrossSectionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.thermal.CrossSectionBlock.test CrossSectionBlock.test.cpp )
-target_compile_options( ACEtk.thermal.CrossSectionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.thermal.CrossSectionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.thermal.CrossSectionBlock COMMAND ACEtk.thermal.CrossSectionBlock.test )
+add_cpp_test( CrossSectionBlock CrossSectionBlock.test.cpp )

--- a/src/ACEtk/thermal/CrossSectionBlock/test/CrossSectionBlock.test.cpp
+++ b/src/ACEtk/thermal/CrossSectionBlock/test/CrossSectionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/thermal/CrossSectionBlock.hpp"
 
 // other includes
@@ -37,7 +40,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -57,7 +60,7 @@ SCENARIO( "CrossSectionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -84,10 +87,10 @@ void verifyChunk( const CrossSectionBlock& chunk ) {
   CHECK( 4 == chunk.numberIncidentEnergies() );
 
   CHECK( 4 == chunk.energies().size() );
-  CHECK( 10. == Approx( chunk.energies().front() ) );
-  CHECK( 40. == Approx( chunk.energies().back() ) );
+  CHECK_THAT( 10., WithinRel( chunk.energies().front() ) );
+  CHECK_THAT( 40., WithinRel( chunk.energies().back() ) );
 
   CHECK( 4 == chunk.crossSections().size() );
-  CHECK( 1. == Approx( chunk.crossSections().front() ) );
-  CHECK( 4. == Approx( chunk.crossSections().back() ) );
+  CHECK_THAT( 1., WithinRel( chunk.crossSections().front() ) );
+  CHECK_THAT( 4., WithinRel( chunk.crossSections().back() ) );
 }

--- a/src/ACEtk/thermal/DiscreteCosines/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/DiscreteCosines/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.thermal.DiscreteCosines.test DiscreteCosines.test.cpp )
-target_compile_options( ACEtk.thermal.DiscreteCosines.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.thermal.DiscreteCosines.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.thermal.DiscreteCosines COMMAND ACEtk.thermal.DiscreteCosines.test )
+add_cpp_test( DiscreteCosines DiscreteCosines.test.cpp )

--- a/src/ACEtk/thermal/DiscreteCosines/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/DiscreteCosines/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_cpp_test( DiscreteCosines DiscreteCosines.test.cpp )
+add_cpp_test( thermal.DiscreteCosines DiscreteCosines.test.cpp )

--- a/src/ACEtk/thermal/DiscreteCosines/test/DiscreteCosines.test.cpp
+++ b/src/ACEtk/thermal/DiscreteCosines/test/DiscreteCosines.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/thermal/DiscreteCosines.hpp"
 
 // other includes
@@ -42,7 +45,7 @@ SCENARIO( "DiscreteCosines" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -62,7 +65,7 @@ SCENARIO( "DiscreteCosines" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -92,10 +95,10 @@ void verifyChunk( const DiscreteCosines& chunk ) {
   CHECK( 34 == chunk.length() );
   CHECK( "DiscreteCosines" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
   CHECK( 33 == chunk.numberDiscreteCosines() );
 
   CHECK( 33 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines().front() ) );
-  CHECK( +1. == Approx( chunk.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( chunk.cosines().back() ) );
 }

--- a/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_cpp_test( DiscreteCosinesWithProbability DiscreteCosinesWithProbability.test.cpp )
+add_cpp_test( thermal.DiscreteCosinesWithProbability DiscreteCosinesWithProbability.test.cpp )

--- a/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.thermal.DiscreteCosinesWithProbability.test DiscreteCosinesWithProbability.test.cpp )
-target_compile_options( ACEtk.thermal.DiscreteCosinesWithProbability.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.thermal.DiscreteCosinesWithProbability.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.thermal.DiscreteCosinesWithProbability COMMAND ACEtk.thermal.DiscreteCosinesWithProbability.test )
+add_cpp_test( DiscreteCosinesWithProbability DiscreteCosinesWithProbability.test.cpp )

--- a/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/DiscreteCosinesWithProbability.test.cpp
+++ b/src/ACEtk/thermal/DiscreteCosinesWithProbability/test/DiscreteCosinesWithProbability.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/thermal/DiscreteCosinesWithProbability.hpp"
 
 // other includes
@@ -45,7 +48,7 @@ SCENARIO( "DiscreteCosinesWithProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -65,7 +68,7 @@ SCENARIO( "DiscreteCosinesWithProbability" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -95,12 +98,12 @@ void verifyChunk( const DiscreteCosinesWithProbability& chunk ) {
   CHECK( 36 == chunk.length() );
   CHECK( "DiscreteCosinesWithProbability" == chunk.name() );
 
-  CHECK( 2.1 == Approx( chunk.energy() ) );
-  CHECK( 0.5 == Approx( chunk.pdf() ) );
-  CHECK( 1.0 == Approx( chunk.cdf() ) );
+  CHECK_THAT( 2.1, WithinRel( chunk.energy() ) );
+  CHECK_THAT( 0.5, WithinRel( chunk.pdf() ) );
+  CHECK_THAT( 1.0, WithinRel( chunk.cdf() ) );
   CHECK( 33 == chunk.numberDiscreteCosines() );
 
   CHECK( 33 == chunk.cosines().size() );
-  CHECK( -1. == Approx( chunk.cosines().front() ) );
-  CHECK( +1. == Approx( chunk.cosines().back() ) );
+  CHECK_THAT( -1., WithinRel( chunk.cosines().front() ) );
+  CHECK_THAT( +1., WithinRel( chunk.cosines().back() ) );
 }

--- a/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.thermal.ElasticAngularDistributionBlock.test ElasticAngularDistributionBlock.test.cpp )
-target_compile_options( ACEtk.thermal.ElasticAngularDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.thermal.ElasticAngularDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.thermal.ElasticAngularDistributionBlock COMMAND ACEtk.thermal.ElasticAngularDistributionBlock.test )
+add_cpp_test( ElasticAngularDistributionBlock ElasticAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_cpp_test( ElasticAngularDistributionBlock ElasticAngularDistributionBlock.test.cpp )
+add_cpp_test( thermal.ElasticAngularDistributionBlock ElasticAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
+++ b/src/ACEtk/thermal/ElasticAngularDistributionBlock/test/ElasticAngularDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/thermal/ElasticAngularDistributionBlock.hpp"
 
 // other includes
@@ -39,7 +42,7 @@ SCENARIO( "ElasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -60,7 +63,7 @@ SCENARIO( "ElasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -93,25 +96,25 @@ void verifyChunk( const ElasticAngularDistributionBlock& chunk ) {
 
   auto cosines = chunk.cosines( 1 );
   CHECK( 3 == cosines.size() );
-  CHECK( -1. == Approx( cosines[0] ) );
-  CHECK( -.9 == Approx( cosines[1] ) );
-  CHECK( +1. == Approx( cosines[2] ) );
+  CHECK_THAT( -1., WithinRel( cosines[0] ) );
+  CHECK_THAT( -.9, WithinRel( cosines[1] ) );
+  CHECK_THAT( +1., WithinRel( cosines[2] ) );
 
   cosines = chunk.cosines( 2 );
   CHECK( 3 == cosines.size() );
-  CHECK( -1. == Approx( cosines[0] ) );
-  CHECK(  0. == Approx( cosines[1] ) );
-  CHECK( +1. == Approx( cosines[2] ) );
+  CHECK_THAT( -1., WithinRel( cosines[0] ) );
+  CHECK_THAT(  0., WithinRel( cosines[1] ) );
+  CHECK_THAT( +1., WithinRel( cosines[2] ) );
 
   cosines = chunk.cosines( 3 );
   CHECK( 3 == cosines.size() );
-  CHECK( -1. == Approx( cosines[0] ) );
-  CHECK(  .5 == Approx( cosines[1] ) );
-  CHECK( +1. == Approx( cosines[2] ) );
+  CHECK_THAT( -1., WithinRel( cosines[0] ) );
+  CHECK_THAT(  .5, WithinRel( cosines[1] ) );
+  CHECK_THAT( +1., WithinRel( cosines[2] ) );
 
   cosines = chunk.cosines( 4 );
   CHECK( 3 == cosines.size() );
-  CHECK( -1. == Approx( cosines[0] ) );
-  CHECK(  .9 == Approx( cosines[1] ) );
-  CHECK( +1. == Approx( cosines[2] ) );
+  CHECK_THAT( -1., WithinRel( cosines[0] ) );
+  CHECK_THAT(  .9, WithinRel( cosines[1] ) );
+  CHECK_THAT( +1., WithinRel( cosines[2] ) );
 }

--- a/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/CMakeLists.txt
@@ -1,18 +1,1 @@
-
-add_executable( ACEtk.thermal.InelasticAngularDistributionBlock.test InelasticAngularDistributionBlock.test.cpp )
-target_compile_options( ACEtk.thermal.InelasticAngularDistributionBlock.test PRIVATE ${${PREFIX}_common_flags}
-$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
-${${PREFIX}_DEBUG_flags}
-$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-$<$<CONFIG:RELEASE>:
-${${PREFIX}_RELEASE_flags}
-$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
-$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-
-${CXX_appended_flags} ${ACEtk_appended_flags} )
-target_link_libraries( ACEtk.thermal.InelasticAngularDistributionBlock.test PUBLIC ACEtk )
-file( GLOB resources "resources/*" )
-foreach( resource ${resources})
-    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
-endforeach()
-add_test( NAME ACEtk.thermal.InelasticAngularDistributionBlock COMMAND ACEtk.thermal.InelasticAngularDistributionBlock.test )
+add_cpp_test( InelasticAngularDistributionBlock InelasticAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/CMakeLists.txt
+++ b/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_cpp_test( InelasticAngularDistributionBlock InelasticAngularDistributionBlock.test.cpp )
+add_cpp_test( thermal.InelasticAngularDistributionBlock InelasticAngularDistributionBlock.test.cpp )

--- a/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/InelasticAngularDistributionBlock.test.cpp
+++ b/src/ACEtk/thermal/InelasticAngularDistributionBlock/test/InelasticAngularDistributionBlock.test.cpp
@@ -1,6 +1,9 @@
-#define CATCH_CONFIG_MAIN
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
 
-#include "catch.hpp"
+// what we are testing
 #include "ACEtk/thermal/InelasticAngularDistributionBlock.hpp"
 
 // other includes
@@ -51,7 +54,7 @@ SCENARIO( "InelasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -72,7 +75,7 @@ SCENARIO( "InelasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -114,7 +117,7 @@ SCENARIO( "InelasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -135,7 +138,7 @@ SCENARIO( "InelasticAngularDistributionBlock" ) {
         auto xss_chunk = chunk.XSS();
         for ( unsigned int i = 0; i < chunk.length(); ++i ) {
 
-          CHECK( xss[i] == Approx( xss_chunk[i] ) );
+          CHECK_THAT( xss[i], WithinRel( xss_chunk[i] ) );
         }
       } // THEN
     } // WHEN
@@ -205,66 +208,66 @@ void verifyChunk( const InelasticAngularDistributionBlock& chunk ) {
   auto data11 = std::get< DiscreteCosines >( chunk.discreteCosineData( 1, 1 ) );
   CHECK( 3 == data11.NC() );
   CHECK( 3 == data11.numberDiscreteCosines() );
-  CHECK( 1. == Approx( data11.energy() ) );
-  CHECK( -1. == Approx( data11.cosines()[0] ) );
-  CHECK( -.9 == Approx( data11.cosines()[1] ) );
-  CHECK( +1. == Approx( data11.cosines()[2] ) );
+  CHECK_THAT( 1., WithinRel( data11.energy() ) );
+  CHECK_THAT( -1., WithinRel( data11.cosines()[0] ) );
+  CHECK_THAT( -.9, WithinRel( data11.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data11.cosines()[2] ) );
 
   auto data12 = std::get< DiscreteCosines >( chunk.discreteCosineData( 1, 2 ) );
   CHECK( 3 == data12.NC() );
   CHECK( 3 == data12.numberDiscreteCosines() );
-  CHECK( 2. == Approx( data12.energy() ) );
-  CHECK( -1. == Approx( data12.cosines()[0] ) );
-  CHECK(  0. == Approx( data12.cosines()[1] ) );
-  CHECK( +1. == Approx( data12.cosines()[2] ) );
+  CHECK_THAT( 2., WithinRel( data12.energy() ) );
+  CHECK_THAT( -1., WithinRel( data12.cosines()[0] ) );
+  CHECK_THAT(  0., WithinRel( data12.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data12.cosines()[2] ) );
 
   auto data21 = std::get< DiscreteCosines >( chunk.discreteCosineData( 2, 1 ) );
   CHECK( 3 == data21.NC() );
   CHECK( 3 == data21.numberDiscreteCosines() );
-  CHECK( 3. == Approx( data21.energy() ) );
-  CHECK( -1. == Approx( data21.cosines()[0] ) );
-  CHECK(  .5 == Approx( data21.cosines()[1] ) );
-  CHECK( +1. == Approx( data21.cosines()[2] ) );
+  CHECK_THAT( 3., WithinRel( data21.energy() ) );
+  CHECK_THAT( -1., WithinRel( data21.cosines()[0] ) );
+  CHECK_THAT(  .5, WithinRel( data21.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data21.cosines()[2] ) );
 
   auto data22 = std::get< DiscreteCosines >( chunk.discreteCosineData( 2, 2 ) );
   CHECK( 3 == data22.NC() );
   CHECK( 3 == data22.numberDiscreteCosines() );
-  CHECK( 4. == Approx( data22.energy() ) );
-  CHECK( -1. == Approx( data22.cosines()[0] ) );
-  CHECK(  .9 == Approx( data22.cosines()[1] ) );
-  CHECK( +1. == Approx( data22.cosines()[2] ) );
+  CHECK_THAT( 4., WithinRel( data22.energy() ) );
+  CHECK_THAT( -1., WithinRel( data22.cosines()[0] ) );
+  CHECK_THAT(  .9, WithinRel( data22.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data22.cosines()[2] ) );
 
   auto data31 = std::get< DiscreteCosines >( chunk.discreteCosineData( 3, 1 ) );
   CHECK( 3 == data31.NC() );
   CHECK( 3 == data31.numberDiscreteCosines() );
-  CHECK( 5. == Approx( data31.energy() ) );
-  CHECK( -1. == Approx( data31.cosines()[0] ) );
-  CHECK(  .4 == Approx( data31.cosines()[1] ) );
-  CHECK( +1. == Approx( data31.cosines()[2] ) );
+  CHECK_THAT( 5., WithinRel( data31.energy() ) );
+  CHECK_THAT( -1., WithinRel( data31.cosines()[0] ) );
+  CHECK_THAT(  .4, WithinRel( data31.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data31.cosines()[2] ) );
 
   auto data32 = std::get< DiscreteCosines >( chunk.discreteCosineData( 3, 2 ) );
   CHECK( 3 == data32.NC() );
   CHECK( 3 == data32.numberDiscreteCosines() );
-  CHECK( 6. == Approx( data32.energy() ) );
-  CHECK( -1. == Approx( data32.cosines()[0] ) );
-  CHECK(  .8 == Approx( data32.cosines()[1] ) );
-  CHECK( +1. == Approx( data32.cosines()[2] ) );
+  CHECK_THAT( 6., WithinRel( data32.energy() ) );
+  CHECK_THAT( -1., WithinRel( data32.cosines()[0] ) );
+  CHECK_THAT(  .8, WithinRel( data32.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data32.cosines()[2] ) );
 
   auto data41 = std::get< DiscreteCosines >( chunk.discreteCosineData( 4, 1 ) );
   CHECK( 3 == data41.NC() );
   CHECK( 3 == data41.numberDiscreteCosines() );
-  CHECK( 7. == Approx( data41.energy() ) );
-  CHECK( -1. == Approx( data41.cosines()[0] ) );
-  CHECK(  .3 == Approx( data41.cosines()[1] ) );
-  CHECK( +1. == Approx( data41.cosines()[2] ) );
+  CHECK_THAT( 7., WithinRel( data41.energy() ) );
+  CHECK_THAT( -1., WithinRel( data41.cosines()[0] ) );
+  CHECK_THAT(  .3, WithinRel( data41.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data41.cosines()[2] ) );
 
   auto data42 = std::get< DiscreteCosines >( chunk.discreteCosineData( 4, 2 ) );
   CHECK( 3 == data42.NC() );
   CHECK( 3 == data42.numberDiscreteCosines() );
-  CHECK( 8. == Approx( data42.energy() ) );
-  CHECK( -1. == Approx( data42.cosines()[0] ) );
-  CHECK(  .7 == Approx( data42.cosines()[1] ) );
-  CHECK( +1. == Approx( data42.cosines()[2] ) );
+  CHECK_THAT( 8., WithinRel( data42.energy() ) );
+  CHECK_THAT( -1., WithinRel( data42.cosines()[0] ) );
+  CHECK_THAT(  .7, WithinRel( data42.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data42.cosines()[2] ) );
 }
 
 void verifyChunkWithIFENG2( const InelasticAngularDistributionBlock& chunk ) {
@@ -294,120 +297,120 @@ void verifyChunkWithIFENG2( const InelasticAngularDistributionBlock& chunk ) {
   auto data11 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 1, 1 ) );
   CHECK( 3 == data11.NC() );
   CHECK( 3 == data11.numberDiscreteCosines() );
-  CHECK(  1. == Approx( data11.energy() ) );
-  CHECK(  .5 == Approx( data11.pdf() ) );
-  CHECK(  .0 == Approx( data11.cdf() ) );
-  CHECK( -1. == Approx( data11.cosines()[0] ) );
-  CHECK( -.9 == Approx( data11.cosines()[1] ) );
-  CHECK( +1. == Approx( data11.cosines()[2] ) );
+  CHECK_THAT(  1., WithinRel( data11.energy() ) );
+  CHECK_THAT(  .5, WithinRel( data11.pdf() ) );
+  CHECK_THAT(  .0, WithinRel( data11.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data11.cosines()[0] ) );
+  CHECK_THAT( -.9, WithinRel( data11.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data11.cosines()[2] ) );
 
   auto data12 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 1, 2 ) );
   CHECK( 3 == data12.NC() );
   CHECK( 3 == data12.numberDiscreteCosines() );
-  CHECK(  2. == Approx( data12.energy() ) );
-  CHECK(  .5 == Approx( data12.pdf() ) );
-  CHECK(  1. == Approx( data12.cdf() ) );
-  CHECK( -1. == Approx( data12.cosines()[0] ) );
-  CHECK(  0. == Approx( data12.cosines()[1] ) );
-  CHECK( +1. == Approx( data12.cosines()[2] ) );
+  CHECK_THAT(  2., WithinRel( data12.energy() ) );
+  CHECK_THAT(  .5, WithinRel( data12.pdf() ) );
+  CHECK_THAT(  1., WithinRel( data12.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data12.cosines()[0] ) );
+  CHECK_THAT(  0., WithinRel( data12.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data12.cosines()[2] ) );
 
   auto data21 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 2, 1 ) );
   CHECK( 3 == data21.NC() );
   CHECK( 3 == data21.numberDiscreteCosines() );
-  CHECK(  3. == Approx( data21.energy() ) );
-  CHECK(  .25 == Approx( data21.pdf() ) );
-  CHECK(  0. == Approx( data21.cdf() ) );
-  CHECK( -1. == Approx( data21.cosines()[0] ) );
-  CHECK(  .5 == Approx( data21.cosines()[1] ) );
-  CHECK( +1. == Approx( data21.cosines()[2] ) );
+  CHECK_THAT(  3., WithinRel( data21.energy() ) );
+  CHECK_THAT(  .25, WithinRel( data21.pdf() ) );
+  CHECK_THAT(  0., WithinRel( data21.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data21.cosines()[0] ) );
+  CHECK_THAT(  .5, WithinRel( data21.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data21.cosines()[2] ) );
 
   auto data22 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 2, 2 ) );
   CHECK( 3 == data22.NC() );
   CHECK( 3 == data22.numberDiscreteCosines() );
-  CHECK(  4. == Approx( data22.energy() ) );
-  CHECK(  .25 == Approx( data22.pdf() ) );
-  CHECK(  0.33 == Approx( data22.cdf() ) );
-  CHECK( -1. == Approx( data22.cosines()[0] ) );
-  CHECK(  .9 == Approx( data22.cosines()[1] ) );
-  CHECK( +1. == Approx( data22.cosines()[2] ) );
+  CHECK_THAT(  4., WithinRel( data22.energy() ) );
+  CHECK_THAT(  .25, WithinRel( data22.pdf() ) );
+  CHECK_THAT(  0.33, WithinRel( data22.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data22.cosines()[0] ) );
+  CHECK_THAT(  .9, WithinRel( data22.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data22.cosines()[2] ) );
 
   auto data23 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 2, 3 ) );
   CHECK( 3 == data23.NC() );
   CHECK( 3 == data23.numberDiscreteCosines() );
-  CHECK(  5. == Approx( data23.energy() ) );
-  CHECK(  .25 == Approx( data23.pdf() ) );
-  CHECK(  0.66 == Approx( data23.cdf() ) );
-  CHECK( -1. == Approx( data23.cosines()[0] ) );
-  CHECK(  .4 == Approx( data23.cosines()[1] ) );
-  CHECK( +1. == Approx( data23.cosines()[2] ) );
+  CHECK_THAT(  5., WithinRel( data23.energy() ) );
+  CHECK_THAT(  .25, WithinRel( data23.pdf() ) );
+  CHECK_THAT(  0.66, WithinRel( data23.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data23.cosines()[0] ) );
+  CHECK_THAT(  .4, WithinRel( data23.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data23.cosines()[2] ) );
 
   auto data24 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 2, 4 ) );
   CHECK( 3 == data24.NC() );
   CHECK( 3 == data24.numberDiscreteCosines() );
-  CHECK(  6. == Approx( data24.energy() ) );
-  CHECK(  .25 == Approx( data24.pdf() ) );
-  CHECK(  1. == Approx( data24.cdf() ) );
-  CHECK( -1. == Approx( data24.cosines()[0] ) );
-  CHECK(  .8 == Approx( data24.cosines()[1] ) );
-  CHECK( +1. == Approx( data24.cosines()[2] ) );
+  CHECK_THAT(  6., WithinRel( data24.energy() ) );
+  CHECK_THAT(  .25, WithinRel( data24.pdf() ) );
+  CHECK_THAT(  1., WithinRel( data24.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data24.cosines()[0] ) );
+  CHECK_THAT(  .8, WithinRel( data24.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data24.cosines()[2] ) );
 
   auto data31 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 3, 1 ) );
   CHECK( 3 == data31.NC() );
   CHECK( 3 == data31.numberDiscreteCosines() );
-  CHECK(  7. == Approx( data31.energy() ) );
-  CHECK(  .33 == Approx( data31.pdf() ) );
-  CHECK(  0. == Approx( data31.cdf() ) );
-  CHECK( -1. == Approx( data31.cosines()[0] ) );
-  CHECK(  .3 == Approx( data31.cosines()[1] ) );
-  CHECK( +1. == Approx( data31.cosines()[2] ) );
+  CHECK_THAT(  7., WithinRel( data31.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data31.pdf() ) );
+  CHECK_THAT(  0., WithinRel( data31.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data31.cosines()[0] ) );
+  CHECK_THAT(  .3, WithinRel( data31.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data31.cosines()[2] ) );
 
   auto data32 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 3, 2 ) );
   CHECK( 3 == data32.NC() );
   CHECK( 3 == data32.numberDiscreteCosines() );
-  CHECK(  8. == Approx( data32.energy() ) );
-  CHECK(  .33 == Approx( data32.pdf() ) );
-  CHECK(  .5 == Approx( data32.cdf() ) );
-  CHECK( -1. == Approx( data32.cosines()[0] ) );
-  CHECK(  .7 == Approx( data32.cosines()[1] ) );
-  CHECK( +1. == Approx( data32.cosines()[2] ) );
+  CHECK_THAT(  8., WithinRel( data32.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data32.pdf() ) );
+  CHECK_THAT(  .5, WithinRel( data32.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data32.cosines()[0] ) );
+  CHECK_THAT(  .7, WithinRel( data32.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data32.cosines()[2] ) );
 
   auto data33 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 3, 3 ) );
   CHECK( 3 == data33.NC() );
   CHECK( 3 == data33.numberDiscreteCosines() );
-  CHECK(  9. == Approx( data33.energy() ) );
-  CHECK(  .33 == Approx( data33.pdf() ) );
-  CHECK(  1. == Approx( data33.cdf() ) );
-  CHECK( -1. == Approx( data33.cosines()[0] ) );
-  CHECK(  .6 == Approx( data33.cosines()[1] ) );
-  CHECK( +1. == Approx( data33.cosines()[2] ) );
+  CHECK_THAT(  9., WithinRel( data33.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data33.pdf() ) );
+  CHECK_THAT(  1., WithinRel( data33.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data33.cosines()[0] ) );
+  CHECK_THAT(  .6, WithinRel( data33.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data33.cosines()[2] ) );
 
   auto data41 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 4, 1 ) );
   CHECK( 3 == data41.NC() );
   CHECK( 3 == data41.numberDiscreteCosines() );
-  CHECK( 10. == Approx( data41.energy() ) );
-  CHECK(  .33 == Approx( data41.pdf() ) );
-  CHECK(  0. == Approx( data41.cdf() ) );
-  CHECK( -1. == Approx( data41.cosines()[0] ) );
-  CHECK(  .2 == Approx( data41.cosines()[1] ) );
-  CHECK( +1. == Approx( data41.cosines()[2] ) );
+  CHECK_THAT( 10., WithinRel( data41.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data41.pdf() ) );
+  CHECK_THAT(  0., WithinRel( data41.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data41.cosines()[0] ) );
+  CHECK_THAT(  .2, WithinRel( data41.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data41.cosines()[2] ) );
 
   auto data42 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 4, 2 ) );
   CHECK( 3 == data42.NC() );
   CHECK( 3 == data42.numberDiscreteCosines() );
-  CHECK( 11. == Approx( data42.energy() ) );
-  CHECK(  .33 == Approx( data42.pdf() ) );
-  CHECK(  .5 == Approx( data42.cdf() ) );
-  CHECK( -1. == Approx( data42.cosines()[0] ) );
-  CHECK(  .5 == Approx( data42.cosines()[1] ) );
-  CHECK( +1. == Approx( data42.cosines()[2] ) );
+  CHECK_THAT( 11., WithinRel( data42.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data42.pdf() ) );
+  CHECK_THAT(  .5, WithinRel( data42.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data42.cosines()[0] ) );
+  CHECK_THAT(  .5, WithinRel( data42.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data42.cosines()[2] ) );
 
   auto data43 = std::get< DiscreteCosinesWithProbability >( chunk.discreteCosineData( 4, 3 ) );
   CHECK( 3 == data43.NC() );
   CHECK( 3 == data43.numberDiscreteCosines() );
-  CHECK( 12. == Approx( data43.energy() ) );
-  CHECK(  .33 == Approx( data43.pdf() ) );
-  CHECK(  1. == Approx( data43.cdf() ) );
-  CHECK( -1. == Approx( data43.cosines()[0] ) );
-  CHECK(  .4 == Approx( data43.cosines()[1] ) );
-  CHECK( +1. == Approx( data43.cosines()[2] ) );
+  CHECK_THAT( 12., WithinRel( data43.energy() ) );
+  CHECK_THAT(  .33, WithinRel( data43.pdf() ) );
+  CHECK_THAT(  1., WithinRel( data43.cdf() ) );
+  CHECK_THAT( -1., WithinRel( data43.cosines()[0] ) );
+  CHECK_THAT(  .4, WithinRel( data43.cosines()[1] ) );
+  CHECK_THAT( +1., WithinRel( data43.cosines()[2] ) );
 }


### PR DESCRIPTION
Updating ACEtk unit tests to use Catch2 v3, removing the outdated catch-adapter dependency