### PR TITLE
Fix/electron populations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if( DEFINED PROJECT_NAME )
 endif()
 
 project( ACEtk
-  VERSION 1.0.1
+  VERSION 1.0.2
   LANGUAGES CXX
 )
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,10 @@
 # Release Notes&mdash;ACEtk
 Given here are some release notes for ACEtk.
 
+## [ACEtk v1.0.2](https://github.com/njoy/ENDFtk/pull/xxx)
+This fixes a bug in ACEtk for photoatomic tables in which the electron subshell populations
+were returned as integers instead of floating point values.
+
 ## [ACEtk v1.0.1](https://github.com/njoy/ENDFtk/pull/133)
 This updates the build system for ACEtk and contains no functional changes.
 

--- a/python/src/electron/ElectronSubshellBlock.python.cpp
+++ b/python/src/electron/ElectronSubshellBlock.python.cpp
@@ -83,14 +83,14 @@ void wrapElectronSubshellBlock( python::module& module, python::module& ) {
   .def_property_readonly(
 
     "EP",
-    [] ( const Block& self ) -> UnsignedIntRange
+    [] ( const Block& self ) -> DoubleRange
        { return self.EP(); },
     "The electron population for each subshell"
   )
   .def_property_readonly(
 
     "populations",
-    [] ( const Block& self ) -> UnsignedIntRange
+    [] ( const Block& self ) -> DoubleRange
        { return self.populations(); },
        "The electron population for each subshell"
   )


### PR DESCRIPTION
This fixes a bug in ACEtk for photoatomic tables in which the electron subshell populations were returned as integers instead of floating point values.