### PR TITLE
Fix/zerolocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ if(ACEtk.python)
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/continuous/SecondaryParticleProductionCrossSectionBlock.python.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/continuous/ProbabilityTable.python.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/continuous/ProbabilityTableBlock.python.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/python/src/continuous/UndefinedDistribution.python.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/photonuclear.python.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/photonuclear/PrincipalCrossSectionBlock.python.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/python/src/photonuclear/SecondaryParticleLocatorBlock.python.cpp

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,7 +6,9 @@ This fixes the following issues in ACEtk:
   - The electron subshell populations are now returned as floating point values instead of
     integer values.
   - An UndefinedDistribution has been introduced to handle cases where locators in the energy
-    distribution block for secondary particles are set to 0 (meaning no data is given).
+    distribution block for secondary particles are set to 0 (meaning no data is given). With
+    earlier versions of ACEtk, this would have lead to a crash because the XSS array was being
+    interpreted incorrectly.
 
 ## [ACEtk v1.0.1](https://github.com/njoy/ENDFtk/pull/133)
 This updates the build system for ACEtk and contains no functional changes.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,8 +2,11 @@
 Given here are some release notes for ACEtk.
 
 ## [ACEtk v1.0.2](https://github.com/njoy/ENDFtk/pull/xxx)
-This fixes a bug in ACEtk for photoatomic tables in which the electron subshell populations
-were returned as integers instead of floating point values.
+This fixes the following issues in ACEtk:
+  - The electron subshell populations are now returned as floating point values instead of
+    integer values.
+  - An UndefinedDistribution has been introduced to handle cases where locators in the energy
+    distribution block for secondary particles are set to 0 (meaning no data is given).
 
 ## [ACEtk v1.0.1](https://github.com/njoy/ENDFtk/pull/133)
 This updates the build system for ACEtk and contains no functional changes.

--- a/python/src/continuous.python.cpp
+++ b/python/src/continuous.python.cpp
@@ -15,6 +15,7 @@ namespace continuous {
   void wrapDelayedNeutronPrecursorData( python::module&, python::module& );
   void wrapDiscretePhotonDistribution( python::module&, python::module& );
   void wrapDistributionGivenElsewhere( python::module&, python::module& );
+  void wrapUndefinedDistribution( python::module&, python::module& );
   void wrapDistributionProbability( python::module&, python::module& );
   void wrapEnergyDependentWattSpectrum( python::module&, python::module& );
   void wrapEquiprobableAngularBins( python::module&, python::module& );
@@ -85,6 +86,7 @@ void wrapContinuous( python::module& module, python::module& viewmodule ) {
   continuous::wrapDelayedNeutronPrecursorData( submodule, viewmodule );
   continuous::wrapDiscretePhotonDistribution( submodule, viewmodule );
   continuous::wrapDistributionGivenElsewhere( submodule, viewmodule );
+  continuous::wrapUndefinedDistribution( submodule, viewmodule );
   continuous::wrapDistributionProbability( submodule, viewmodule );
   continuous::wrapEnergyDependentWattSpectrum( submodule, viewmodule );
   continuous::wrapEquiprobableAngularBins( submodule, viewmodule );

--- a/python/src/continuous/UndefinedDistribution.python.cpp
+++ b/python/src/continuous/UndefinedDistribution.python.cpp
@@ -24,9 +24,9 @@ void wrapUndefinedDistribution( python::module& module, python::module& ) {
     module,
     "UndefinedDistribution",
     "The distribution is undefined\n\n"
-    "The UndefinedDistribution class contains contains no data. It is a\n"
-    "convenience interface object used in the DLWH block when no energy\n"
-    "distribution data is given."
+    "The UndefinedDistribution class contains no data. It is a convenience\n"
+    "interface object used in the DLWH block when no energy distribution data\n"
+    "is given."
   );
 
   // wrap the block

--- a/python/src/continuous/UndefinedDistribution.python.cpp
+++ b/python/src/continuous/UndefinedDistribution.python.cpp
@@ -1,0 +1,43 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// local includes
+#include "ACEtk/continuous/UndefinedDistribution.hpp"
+#include "definitions.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+namespace continuous {
+
+void wrapUndefinedDistribution( python::module& module, python::module& ) {
+
+  // type aliases
+  using Block = njoy::ACEtk::continuous::UndefinedDistribution;
+
+  // wrap views created by this block
+
+  // create the block
+  python::class_< Block > block(
+
+    module,
+    "UndefinedDistribution",
+    "The distribution is undefined\n\n"
+    "The UndefinedDistribution class contains contains no data. It is a\n"
+    "convenience interface object used in the DLWH block when no energy\n"
+    "distribution data is given."
+  );
+
+  // wrap the block
+  block
+  .def(
+
+    python::init<>(),
+    "Initialise the block\n\n"
+    "Arguments:\n"
+    "    self    the block"
+  );
+}
+
+} // continuous namespace

--- a/src/ACEtk/base/BlockWithLocators/src/generateData.hpp
+++ b/src/ACEtk/base/BlockWithLocators/src/generateData.hpp
@@ -2,7 +2,12 @@
 // a cross section data block from the SIG block) that cannot use the basic
 // constructor of a left an right iterator (e.g. when the data block is a
 // variant).
-static Data generateData( std::size_t, Iterator left, Iterator right ) {
+static Data generateData( std::size_t locator, Iterator left, Iterator right ) {
+
+  if ( locator == 0 ) {
+
+    Log::warning( "Detected a locator = 0 that may not be properly handled" );
+  }
 
   return { left, right };
 }

--- a/src/ACEtk/continuous/EnergyDistributionBlock.hpp
+++ b/src/ACEtk/continuous/EnergyDistributionBlock.hpp
@@ -22,6 +22,7 @@
 #include "ACEtk/continuous/EnergyAngleDistributionData.hpp"
 #include "ACEtk/continuous/AngleEnergyDistributionData.hpp"
 #include "ACEtk/continuous/MultiDistributionData.hpp"
+#include "ACEtk/continuous/UndefinedDistribution.hpp"
 #include "ACEtk/continuous/TabulatedMultiplicity.hpp"
 #include "ACEtk/ReferenceFrame.hpp"
 
@@ -43,7 +44,8 @@ using EnergyDistributionData = std::variant< EquiprobableOutgoingEnergyBinData,
                                              TwoBodyTransferDistribution,
                                              EnergyAngleDistributionData,
                                              AngleEnergyDistributionData,
-                                             MultiDistributionData >;
+                                             MultiDistributionData,
+                                             UndefinedDistribution >;
 using MultiplicityData = std::variant< unsigned int, TabulatedMultiplicity >;
 
 /**

--- a/src/ACEtk/continuous/EnergyDistributionBlock/src/generateBlocks.hpp
+++ b/src/ACEtk/continuous/EnergyDistributionBlock/src/generateBlocks.hpp
@@ -87,10 +87,18 @@ void generateBlocks() {
 
   for ( unsigned int index = 1; index <= this->NR(); ++index ) {
 
+    // zero lcoators in the LDLW are not allowed
+    std::size_t locator = this->LDLW( index );
+    if ( locator == 0 ) {
+
+      Log::error( "Detected a locator = 0 in the LDLW block for reaction with index "
+                  "= {}", index );
+      throw std::exception();
+    }
+
     // data : one-based index to the start of the data block
     // data + locator - 1 : one-based index to the start of cross section data
     std::size_t data = std::distance( this->begin(), this->iter() ) + 1;
-    std::size_t locator = this->LDLW( index );
     std::size_t multiplicity = index == this->NR()
                                ? 0
                                : this->TYR().multiplicity( index + 1 );

--- a/src/ACEtk/continuous/EnergyDistributionBlock/src/generateXSS.hpp
+++ b/src/ACEtk/continuous/EnergyDistributionBlock/src/generateXSS.hpp
@@ -71,6 +71,7 @@ generateXSS( std::vector< EnergyDistributionData >&& distributions,
         tools::overload{
 
           [] ( const MultiDistributionData& ) { /* nothing to do here */ },
+          [] ( const UndefinedDistribution& ) { /* nothing to do here */ },
           [ &xss, &idat, locator ] ( const auto& value ) {
 
             idat = locator + 3 + 1 + 5;
@@ -139,6 +140,7 @@ generateXSS( std::vector< EnergyDistributionData >&& distributions,
                       idat );
             xss.insert( xss.end(), temp.begin(), temp.end() );
           },
+          [] ( const UndefinedDistribution& ) { /* nothing to do here */ },
           [ &xss ] ( const auto& value ) {
 
             xss.insert( xss.end(), value.begin(), value.end() );

--- a/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock.hpp
+++ b/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock.hpp
@@ -22,6 +22,7 @@
 #include "ACEtk/continuous/EnergyAngleDistributionData.hpp"
 #include "ACEtk/continuous/AngleEnergyDistributionData.hpp"
 #include "ACEtk/continuous/MultiDistributionData.hpp"
+#include "ACEtk/continuous/UndefinedDistribution.hpp"
 
 namespace njoy {
 namespace ACEtk {
@@ -41,7 +42,8 @@ using EnergyDistributionData = std::variant< EquiprobableOutgoingEnergyBinData,
                                              TwoBodyTransferDistribution,
                                              EnergyAngleDistributionData,
                                              AngleEnergyDistributionData,
-                                             MultiDistributionData >;
+                                             MultiDistributionData,
+                                             UndefinedDistribution >;
 
 /**
  *  @class

--- a/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/src/generateData.hpp
+++ b/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/src/generateData.hpp
@@ -1,84 +1,92 @@
 static EnergyDistributionData
 generateData( std::size_t locator, Iterator left, Iterator right ) {
 
-  // left points to the LNW value - single law if zero
-  unsigned int lnw = static_cast< unsigned int >( std::round( *left ) );
-  if ( lnw == 0 ) {
+  // locators can be zero
+  if ( locator == 0 ) {
 
-    EnergyDistributionType law = static_cast< EnergyDistributionType >( std::round( *( left + 1 ) ) );
-    std::size_t idat = static_cast< std::size_t >( std::round( *( left + 2 ) ) );
-    std::size_t nr = static_cast< std::size_t >( std::round( *( left + 3 ) ) );
-    std::size_t ne = static_cast< std::size_t >( std::round( *( left + 3 + 2 * nr + 1 ) ) );
-    double emin = *( left + 3 + 2 * nr + 1 + 1 );
-    double emax = *( left + 3 + 2 * nr + 1 + ne );
-
-    // compute iterators into the xss array
-    const auto start = left + idat - locator;
-
-    // switch on the law and return the appropriate data
-    switch ( law ) {
-
-      case EnergyDistributionType::DiscretePhoton : {
-
-        return DiscretePhotonDistribution( start, right, emin, emax );
-      }
-      case EnergyDistributionType::LevelScattering : {
-
-        return LevelScatteringDistribution( start, right, emin, emax );
-      }
-      case EnergyDistributionType::TwoBodyTransfer : {
-
-        return TwoBodyTransferDistribution( start, right, emin, emax );
-      }
-      case EnergyDistributionType::NBodyPhaseSpace : {
-
-        return NBodyPhaseSpaceDistribution( start, right, emin, emax );
-      }
-      case EnergyDistributionType::TabulatedEnergy : {
-
-        return OutgoingEnergyDistributionData( idat, start, right );
-      }
-      case EnergyDistributionType::KalbachMann : {
-
-        return KalbachMannDistributionData( idat, start, right );
-      }
-      case EnergyDistributionType::TabulatedEnergyAngle : {
-
-        return EnergyAngleDistributionData( idat, start, right );
-      }
-      case EnergyDistributionType::TabulatedAngleEnergy : {
-
-        return AngleEnergyDistributionData( idat, start, right );
-      }
-      case EnergyDistributionType::Equiprobable : {
-
-        return EquiprobableOutgoingEnergyBinData( start, right );
-      }
-      case EnergyDistributionType::GeneralEvaporation : {
-
-        return GeneralEvaporationSpectrum( start, right );
-      }
-      case EnergyDistributionType::SimpleMaxwellianFission : {
-
-        return SimpleMaxwellianFissionSpectrum( start, right );
-      }
-      case EnergyDistributionType::Evaporation : {
-
-        return EvaporationSpectrum( start, right );
-      }
-      case EnergyDistributionType::Watt : {
-
-        return EnergyDependentWattSpectrum( start, right );
-      }
-      default : {
-
-        throw std::runtime_error( "DLWH law currently not implemented: "
-                                  + std::to_string( static_cast< short >( law ) ) );
-      }
-    }
+    return UndefinedDistribution();
   }
   else {
 
-    return MultiDistributionData( locator, left, right );
+    // left points to the LNW value - single law if zero
+    unsigned int lnw = static_cast< unsigned int >( std::round( *left ) );
+    if ( lnw == 0 ) {
+
+      EnergyDistributionType law = static_cast< EnergyDistributionType >( std::round( *( left + 1 ) ) );
+      std::size_t idat = static_cast< std::size_t >( std::round( *( left + 2 ) ) );
+      std::size_t nr = static_cast< std::size_t >( std::round( *( left + 3 ) ) );
+      std::size_t ne = static_cast< std::size_t >( std::round( *( left + 3 + 2 * nr + 1 ) ) );
+      double emin = *( left + 3 + 2 * nr + 1 + 1 );
+      double emax = *( left + 3 + 2 * nr + 1 + ne );
+
+      // compute iterators into the xss array
+      const auto start = left + idat - locator;
+
+      // switch on the law and return the appropriate data
+      switch ( law ) {
+
+        case EnergyDistributionType::DiscretePhoton : {
+
+          return DiscretePhotonDistribution( start, right, emin, emax );
+        }
+        case EnergyDistributionType::LevelScattering : {
+
+          return LevelScatteringDistribution( start, right, emin, emax );
+        }
+        case EnergyDistributionType::TwoBodyTransfer : {
+
+          return TwoBodyTransferDistribution( start, right, emin, emax );
+        }
+        case EnergyDistributionType::NBodyPhaseSpace : {
+
+          return NBodyPhaseSpaceDistribution( start, right, emin, emax );
+        }
+        case EnergyDistributionType::TabulatedEnergy : {
+
+          return OutgoingEnergyDistributionData( idat, start, right );
+        }
+        case EnergyDistributionType::KalbachMann : {
+
+          return KalbachMannDistributionData( idat, start, right );
+        }
+        case EnergyDistributionType::TabulatedEnergyAngle : {
+
+          return EnergyAngleDistributionData( idat, start, right );
+        }
+        case EnergyDistributionType::TabulatedAngleEnergy : {
+
+          return AngleEnergyDistributionData( idat, start, right );
+        }
+        case EnergyDistributionType::Equiprobable : {
+
+          return EquiprobableOutgoingEnergyBinData( start, right );
+        }
+        case EnergyDistributionType::GeneralEvaporation : {
+
+          return GeneralEvaporationSpectrum( start, right );
+        }
+        case EnergyDistributionType::SimpleMaxwellianFission : {
+
+          return SimpleMaxwellianFissionSpectrum( start, right );
+        }
+        case EnergyDistributionType::Evaporation : {
+
+          return EvaporationSpectrum( start, right );
+        }
+        case EnergyDistributionType::Watt : {
+
+          return EnergyDependentWattSpectrum( start, right );
+        }
+        default : {
+
+          throw std::runtime_error( "DLWH law currently not implemented: "
+                                    + std::to_string( static_cast< short >( law ) ) );
+        }
+      }
+    }
+    else {
+
+      return MultiDistributionData( locator, left, right );
+    }
   }
 }

--- a/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/src/generateXSS.hpp
+++ b/src/ACEtk/continuous/SecondaryParticleEnergyDistributionBlock/src/generateXSS.hpp
@@ -40,6 +40,7 @@ generateXSS( std::vector< EnergyDistributionData >&& distributions, bool ) {
         tools::overload{
 
           [] ( const MultiDistributionData& ) { /* nothing to do here */ },
+          [] ( const UndefinedDistribution& ) { /* nothing to do here */ },
           [ &xss, &idat, offset ] ( const auto& value ) {
 
             idat = offset + 3 + 1 + 5;
@@ -108,6 +109,7 @@ generateXSS( std::vector< EnergyDistributionData >&& distributions, bool ) {
                       idat );
             xss.insert( xss.end(), temp.begin(), temp.end() );
           },
+          [] ( const UndefinedDistribution& ) { /* nothing to do here */ },
           [ &xss ] ( const auto& value ) {
 
             xss.insert( xss.end(), value.begin(), value.end() );

--- a/src/ACEtk/continuous/UndefinedDistribution.hpp
+++ b/src/ACEtk/continuous/UndefinedDistribution.hpp
@@ -1,0 +1,36 @@
+#ifndef NJOY_ACETK_CONTINUOUS_UNDEFINEDDISTRIBUTION
+#define NJOY_ACETK_CONTINUOUS_UNDEFINEDDISTRIBUTION
+
+// system includes
+
+// other includes
+
+namespace njoy {
+namespace ACEtk {
+namespace continuous {
+
+/**
+ *  @class
+ *  @brief The distribution is undefined
+ *
+ *  The UndefinedDistribution class contains contains no data. It is a
+ *  convenience interface object used in the DLWH block when no energy
+ *  distribution data is given.
+ */
+class UndefinedDistribution {
+
+  /* fields */
+
+  /* auxiliary functions */
+
+public:
+
+  /* constructor */
+  UndefinedDistribution() = default;
+};
+
+} // continuous namespace
+} // ACEtk namespace
+} // njoy namespace
+
+#endif

--- a/src/ACEtk/continuous/UndefinedDistribution.hpp
+++ b/src/ACEtk/continuous/UndefinedDistribution.hpp
@@ -13,9 +13,9 @@ namespace continuous {
  *  @class
  *  @brief The distribution is undefined
  *
- *  The UndefinedDistribution class contains contains no data. It is a
- *  convenience interface object used in the DLWH block when no energy
- *  distribution data is given.
+ *  The UndefinedDistribution class contains no data. It is a convenience
+ *  interface object used in the DLWH block when no energy distribution data
+ *  is given.
  */
 class UndefinedDistribution {
 


### PR DESCRIPTION
An UndefinedDistribution has been introduced to handle cases where locators in the energy distribution block for secondary particles are set to 0 (meaning no data is given). With earlier versions of ACEtk, this would have lead to a crash because the XSS array was being interpreted incorrectly.